### PR TITLE
Allow to reproduce app stuck loading issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ A few URL parameters will modify the behaviour of the viewer:
 
 - `noLimit` disable the navigation limits (sphere and lava). Use noLimit=false to enforce limits on local dev.
 - `assetIds` display some additional Cesium ION 3dtilesets (coma separated list of CesiumIon ids)
+- `initialScreenSpaceError` define the visual quality (default: 10000)
 - `maximumScreenSpaceError` define the visual quality (default: 2.0 except for localhost which is 20.0)
 - `ownterrain=false` disables the Swisstopo terrain (mind that their is only data in the swissrectangle)
 - `swissrectangle=false` do not restrict rendering to the Swiss rectangle

--- a/src/index.js
+++ b/src/index.js
@@ -70,7 +70,9 @@ const scene = viewer.scene;
  * @type {import('cesium/Source/Scene/Globe.js').default}
  */
 const globe = scene.globe;
-globe.maximumScreenSpaceError = 10000;
+
+const searchParams = new URLSearchParams(document.location.search);
+globe.maximumScreenSpaceError = parseFloat(searchParams.get('initialScreenSpaceError') || '10000');
 
 // setup auth component
 const auth = document.querySelector('ngm-auth');
@@ -89,7 +91,6 @@ const unlisten = globe.tileLoadProgressEvent.addEventListener(() => {
   if (globe.tilesLoaded) {
     unlisten();
     let sse = 2;
-    const searchParams = new URLSearchParams(document.location.search);
     if (document.location.hostname === 'localhost') {
       sse = 20;
     }


### PR DESCRIPTION
Some Swisstopo terrain is broken.
CesiumJS gets stuck while trying to upscale it.

To reproduce:
- open http://localhost:8000/?initialScreenSpaceError=20
- the loading screen stays displayed forever.

To workaround use Cesium terrain:
- open http://localhost:8000/?initialScreenSpaceError=20&ownterrain=false
- it works