### PR TITLE
Run build-storybook in the dist target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,3 +7,4 @@ dist:
 	npm ci
 	npm run lint
 	npm run build
+	npm run build-storybook


### PR DESCRIPTION
Otherwise the deploy_to_s3 script fails