### PR TITLE
Change geocat-URL

### DIFF
--- a/ui/src/elements/ngm-layer-legend.ts
+++ b/ui/src/elements/ngm-layer-legend.ts
@@ -63,5 +63,5 @@ const GEOCAT_LANG_CODE = {
 
 function geocatLink(id: string) {
   const lang = GEOCAT_LANG_CODE[i18next.language];
-  return `https://www.geocat.ch/geonetwork/srv/${lang}/md.viewer#/full_view/${id}/tab/complete`;
+  return `https://www.geocat.ch/geonetwork/srv/${lang}/catalog.search#/metadata/${id}`;
 }


### PR DESCRIPTION
Line 66 ,modified, because structure of geocat.ch-URL changes as documented here: https://github.com/geoadmin/geocat/wiki/CHANGELOG-V3.x-to-V4.x-(for-users)