### PR TITLE
Fix data catalog / layers display interactions

### DIFF
--- a/ui/src/elements/ngm-side-bar.ts
+++ b/ui/src/elements/ngm-side-bar.ts
@@ -432,7 +432,7 @@ export class SideBar extends LitElementI18n {
         layer.displayed = false;
         layer.visible = false;
         layer.remove && layer.remove();
-        const idx = this.activeLayers.findIndex(l => l === layer);
+        const idx = this.activeLayers.findIndex(l => l.label === layer.label);
         this.activeLayers.splice(idx, 1);
       } else {
         layer.visible = true;
@@ -456,10 +456,12 @@ export class SideBar extends LitElementI18n {
   onLayerChanged(evt) {
     this.queryManager!.hideObjectInformation();
     this.catalogLayers = [...this.catalogLayers];
+    this.activeLayers = [...this.activeLayers];
     syncLayersParam(this.activeLayers);
     if (evt.detail) {
       this.maybeShowVisibilityHint(evt.detail);
     }
+    this.requestUpdate();
   }
 
   maybeShowVisibilityHint(config: Config) {

--- a/ui/src/elements/ngm-side-bar.ts
+++ b/ui/src/elements/ngm-side-bar.ts
@@ -665,7 +665,8 @@ export class SideBar extends LitElementI18n {
       zoomToBbox: true,
       opacity: DEFAULT_LAYER_OPACITY,
       notSaveToPermalink: true,
-      ownKml: true
+      ownKml: true,
+      opacityDisabled: true
     };
 
     this.requestUpdate();

--- a/ui/src/layers/ngm-layers-item.ts
+++ b/ui/src/layers/ngm-layers-item.ts
@@ -32,6 +32,8 @@ export class LayerTreeItem extends LitElementI18n {
   accessor config!: Config;
   @property({type: Boolean})
   accessor changeOrderActive = false;
+  @property({type: Boolean})
+  accessor layerVisible = false;
   @state()
   accessor loading = 0;
   @state()
@@ -45,9 +47,6 @@ export class LayerTreeItem extends LitElementI18n {
 
   firstUpdated() {
     $(this.querySelector('.ui.dropdown')).dropdown();
-    if (!this.config.opacity) {
-      this.config.opacity = DEFAULT_LAYER_OPACITY;
-    }
   }
 
   updated(changedProps) {
@@ -59,6 +58,9 @@ export class LayerTreeItem extends LitElementI18n {
 
   connectedCallback() {
     super.connectedCallback();
+    if (!this.config.opacity) {
+      this.config.opacity = DEFAULT_LAYER_OPACITY;
+    }
     if (!this.actions || !this.actions.listenForEvent) return;
     this.loading = 0;
     const callback = (pending, processing) => {
@@ -84,6 +86,7 @@ export class LayerTreeItem extends LitElementI18n {
 
   changeVisibility() {
     this.config.visible = !this.config.visible;
+    this.layerVisible = !this.layerVisible;
     this.actions.changeVisibility(this.config, this.config.visible);
     this.dispatchEvent(new CustomEvent('layerChanged'));
     this.requestUpdate();
@@ -182,10 +185,10 @@ export class LayerTreeItem extends LitElementI18n {
       </div>
 
       <div ?hidden=${this.loading > 0 || this.changeOrderActive}
-           title=${this.config.visible ? i18next.t('dtd_hide') : i18next.t('dtd_show')}
+           title=${this.layerVisible ? i18next.t('dtd_hide') : i18next.t('dtd_show')}
            class="ngm-layer-icon ${classMap({
-             'ngm-visible-icon': !!this.config.visible,
-             'ngm-invisible-icon': !this.config.visible
+             'ngm-visible-icon': !!this.layerVisible,
+             'ngm-invisible-icon': !this.layerVisible
            })}" @click=${this.changeVisibility}>
       </div>
       <div ?hidden=${this.loading === 0} class="ngm-determinate-loader">
@@ -199,8 +202,8 @@ export class LayerTreeItem extends LitElementI18n {
           <i class=${this.config.restricted ? 'lock icon' : ''}></i>
           ${i18next.t(this.config.label)} ${this.sublabel}
         </label>
-        <label ?hidden=${!this.config.setOpacity}>${(this.config.opacity! * 100).toFixed()} %</label>
-        <input type="range" class="ngm-slider" ?hidden=${!this.config.setOpacity}
+        <label ?hidden=${this.config.opacityDisabled}>${(this.config.opacity! * 100).toFixed()} %</label>
+        <input type="range" class="ngm-slider" ?hidden=${this.config.opacityDisabled}
                style="background-image: linear-gradient(to right, var(--ngm-interaction-active), var(--ngm-interaction-active) ${this.config.opacity! * 100}%, white ${this.config.opacity! * 100}%)"
                min=0 max=1 step=0.01
                .value=${this.config.opacity?.toString() || '1'}

--- a/ui/src/layers/ngm-layers-item.ts
+++ b/ui/src/layers/ngm-layers-item.ts
@@ -32,8 +32,6 @@ export class LayerTreeItem extends LitElementI18n {
   accessor config!: Config;
   @property({type: Boolean})
   accessor changeOrderActive = false;
-  @property({type: Boolean})
-  accessor layerVisible = false;
   @state()
   accessor loading = 0;
   @state()
@@ -185,10 +183,10 @@ export class LayerTreeItem extends LitElementI18n {
       </div>
 
       <div ?hidden=${this.loading > 0 || this.changeOrderActive}
-           title=${this.layerVisible ? i18next.t('dtd_hide') : i18next.t('dtd_show')}
+           title=${this.config.visible ? i18next.t('dtd_hide') : i18next.t('dtd_show')}
            class="ngm-layer-icon ${classMap({
-             'ngm-visible-icon': !!this.layerVisible,
-             'ngm-invisible-icon': !this.layerVisible
+             'ngm-visible-icon': !!this.config.visible,
+             'ngm-invisible-icon': !this.config.visible
            })}" @click=${this.changeVisibility}>
       </div>
       <div ?hidden=${this.loading === 0} class="ngm-determinate-loader">

--- a/ui/src/layers/ngm-layers-item.ts
+++ b/ui/src/layers/ngm-layers-item.ts
@@ -84,7 +84,6 @@ export class LayerTreeItem extends LitElementI18n {
 
   changeVisibility() {
     this.config.visible = !this.config.visible;
-    this.layerVisible = !this.layerVisible;
     this.actions.changeVisibility(this.config, this.config.visible);
     this.dispatchEvent(new CustomEvent('layerChanged'));
     this.requestUpdate();

--- a/ui/src/layers/ngm-layers.ts
+++ b/ui/src/layers/ngm-layers.ts
@@ -69,6 +69,7 @@ export default class LayerTree extends LitElementI18n {
       <ngm-layers-item
         .actions=${this.actions}
         .config=${config}
+        .layerVisible=${config.visible!}
         .changeOrderActive=${this.changeOrderActive}
         @removeDisplayedLayer=${() => this.dispatchEvent(new CustomEvent('removeDisplayedLayer', {detail}))}
         @zoomTo=${() => this.dispatchEvent(new CustomEvent('zoomTo', {detail: config}))}

--- a/ui/src/layers/ngm-layers.ts
+++ b/ui/src/layers/ngm-layers.ts
@@ -69,7 +69,6 @@ export default class LayerTree extends LitElementI18n {
       <ngm-layers-item
         .actions=${this.actions}
         .config=${config}
-        .layerVisible=${config.visible!}
         .changeOrderActive=${this.changeOrderActive}
         @removeDisplayedLayer=${() => this.dispatchEvent(new CustomEvent('removeDisplayedLayer', {detail}))}
         @zoomTo=${() => this.dispatchEvent(new CustomEvent('zoomTo', {detail: config}))}
@@ -87,7 +86,7 @@ export default class LayerTree extends LitElementI18n {
     return html`
       ${repeat(
         reverse,
-        (config) => config.label,
+        (config) => `${config.label}_${config.visible}_${config.opacity}`,
         (config, idx) => this.createLayerTemplate(config, idx, len)
       )}
     `;


### PR DESCRIPTION
Besides the issue mentioned in the ticket, this PR also fixes:

- Opacity bar not displayed on initial load for two default displayed layers (cross section and borehole) 

- Some layers have NaN% as label for the opacity (e.g. Temperatures - Horizon (TUMa))
 