### PR TITLE
fix: use output.dir in rollup config

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -39,7 +39,7 @@
     const l = document.location;
     const li = l.pathname.lastIndexOf('/');
     const path = li != -1 ? l.pathname.substring(0, li) : l.pathname;
-    script.src = `${l.origin}${path}/${debug ? 'bundle.debug.js' : 'bundle.min.js'}`;
+    script.src = `${l.origin}${path}/${debug ? 'debug/index.js' : 'min/index.js'}`;
   </script>
   <script type="module" id="app-script" crossorigin="use-credentials"></script>
 </body>

--- a/ui/rollup.config.js
+++ b/ui/rollup.config.js
@@ -19,7 +19,7 @@ const extensions = ['.ts', '.js'];
 const config = {
   input: 'src/index.ts',
   output: [{
-    file: 'dist/bundle.debug.js',
+    dir: 'dist/debug',
     sourcemap: true,
     format: 'esm',
   }],
@@ -103,7 +103,7 @@ const config = {
 
 if (process.env.mode === 'production') {
   config.output.push({
-    file: 'dist/bundle.min.js',
+    dir: 'dist/min',
     sourcemap: true,
     format: 'esm',
     plugins: [

--- a/ui/webpack.config.js
+++ b/ui/webpack.config.js
@@ -61,7 +61,7 @@ export default {
     }
   },
   output: {
-    filename: 'bundle.debug.js',
+    filename: 'debug/index.js',
   },
   devtool: 'eval',
   module: {


### PR DESCRIPTION
credential-provider-cognito-identity is now loading script with `await import`; multiple js files are generated by rollup