### PR TITLE
Update layertree.ts - Make public boreholes private

### DIFF
--- a/ui/src/layers/ngm-catalog.ts
+++ b/ui/src/layers/ngm-catalog.ts
@@ -33,6 +33,8 @@ export class Catalog extends LitElementI18n {
       node => !(node.restricted && (!this.userGroups.includes(node.restricted)))
       ).map(node => this.getCategoryOrLayerTemplate(node, 'second-level'));
 
+    if (!content?.length) return html``;
+
     return html`
       <div class="ui accordion">
         <div class="title ${level}">

--- a/ui/src/layertree.ts
+++ b/ui/src/layertree.ts
@@ -606,8 +606,8 @@ const geo_base: LayerTreeNode = {
           opacity: DEFAULT_LAYER_OPACITY,
           pickable: true,
           visible: false,
-          displayed: false, //true,
-          restricted: 'ngm-prod-privileged', // the group required to see this layer
+          displayed: false, // private until they have been re-integrated
+          restricted: 'ngm-prod-privileged', // private until they have been re-integrated
           // Temporarily disable the boreholes download, see https://jira.camptocamp.com/browse/GSNGM-936
           // downloadDataType: 'csv',
           // downloadDataPath: 'https://download.swissgeol.ch/boreholes/bh_open_20210201_00.csv',

--- a/ui/src/layertree.ts
+++ b/ui/src/layertree.ts
@@ -606,7 +606,8 @@ const geo_base: LayerTreeNode = {
           opacity: DEFAULT_LAYER_OPACITY,
           pickable: true,
           visible: false,
-          displayed: true,
+          displayed: false, //true,
+          restricted: 'ngm-prod-privileged', // the group required to see this layer
           // Temporarily disable the boreholes download, see https://jira.camptocamp.com/browse/GSNGM-936
           // downloadDataType: 'csv',
           // downloadDataPath: 'https://download.swissgeol.ch/boreholes/bh_open_20210201_00.csv',


### PR DESCRIPTION
The boreholes shall be accessible only for users in the "ngm-prod-privileged"-group. After re-integration of boreholes it will accessable publicly.

cf. GSNGM-1156