### PR TITLE
GSNGM-896: remove "i" icon in toolboxes

### DIFF
--- a/ui/src/images/i_info.svg
+++ b/ui/src/images/i_info.svg
@@ -1,4 +1,0 @@
-<svg id="I_info" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-  <rect id="Rechteck_1627" data-name="Rechteck 1627" width="24" height="24" transform="translate(0 0)" fill="rgba(252,252,252,0)"/>
-  <path id="Pfad_1736" data-name="Pfad 1736" d="M706.178,371.747a12,12,0,1,0,12,12A12,12,0,0,0,706.178,371.747Zm0,22a10,10,0,1,1,10-10A10,10,0,0,1,706.178,393.747Zm-1-12h2v8h-2Zm0-4h2v2h-2Z" transform="translate(-694.178 -371.747)" fill="#0b7285"/>
-</svg>

--- a/ui/src/style/icons.css
+++ b/ui/src/style/icons.css
@@ -240,14 +240,6 @@
   background-color: var(--ngm-interaction);
 }
 
-.ngm-info-icon {
-  width: 24px;
-  height: 24px;
-  mask: url('./images/i_info.svg') no-repeat center;
-  -webkit-mask: url('./images/i_info.svg') no-repeat center;
-  background-color: var(--ngm-interaction);
-}
-
 .ngm-action-menu-icon {
   width: 24px;
   height: 24px;

--- a/ui/src/style/ngm-toolbox.css
+++ b/ui/src/style/ngm-toolbox.css
@@ -86,11 +86,6 @@ data-download .ngm-action-list-item.active  {
   background-color: var(--ngm-action-hover);
 }
 
-.ngm-draw-hint > .ngm-info-icon,
-.data-download-hint > .ngm-info-icon {
-  margin-left: auto;
-}
-
 .ngm-slice-side {
   display: flex;
   font: normal normal 500 14px/28px Inter;

--- a/ui/src/toolbox/data-download.ts
+++ b/ui/src/toolbox/data-download.ts
@@ -88,7 +88,6 @@ export class DataDownload extends LitElementI18n {
         `) : html`
         <div class="data-download-hint">
           ${i18next.t('tbx_data_download_hint')}
-          <div class="ngm-info-icon"></div>
         </div>
       `;
 
@@ -103,7 +102,7 @@ export class DataDownload extends LitElementI18n {
     return html`
       <ngm-draw-section .enabledTypes=${['rectangle']} .showUpload=${false}></ngm-draw-section>
       <div class="ngm-divider"></div>
-      <ngm-geometries-list 
+      <ngm-geometries-list
         .selectedId=${this.selectedGeometryId}
         .disabledTypes=${['point', 'polygon', 'line']}
         .optionsTemplate=${(geom: NgmGeometry) => this.downloadOptionsTemplate(geom)}

--- a/ui/src/toolbox/ngm-draw-section.ts
+++ b/ui/src/toolbox/ngm-draw-section.ts
@@ -85,7 +85,6 @@ export class NgmDrawSection extends LitElementI18n {
               </div>
               <div ?hidden=${!active} class="ngm-draw-hint">
                 ${i18next.t('tbx_area_of_interest_add_hint')}
-                <div class="ngm-info-icon"></div>
               </div>
               <ngm-line-info
                   .hidden="${!active || it.type !== 'line'}"

--- a/ui/src/toolbox/ngm-measure.ts
+++ b/ui/src/toolbox/ngm-measure.ts
@@ -74,7 +74,6 @@ export class NgmMeasure extends LitElementI18n {
                     </div>
                     <div class="ngm-draw-hint" .hidden="${!this.active}">
                         ${i18next.t('tbx_measure_hint')}
-                        <div class="ngm-info-icon"></div>
                     </div>
                     <ngm-line-info
                             .hidden="${!this.active}"

--- a/ui/src/toolbox/ngm-slicer.ts
+++ b/ui/src/toolbox/ngm-slicer.ts
@@ -271,7 +271,6 @@ export class NgmSlicer extends LitElementI18n {
       <div class="ngm-draw-hint"
            ?hidden=${(!id && this.slicingType !== type) || id !== this.sliceGeomId || !this.slicer!.draw.active}>
         ${i18next.t('tbx_slice_draw_hint')}
-        <div class="ngm-info-icon"></div>
       </div>
       <div class="ngm-slice-options"
            ?hidden=${(!id && this.slicingType !== type) || id !== this.sliceGeomId || this.slicer!.draw.active}>


### PR DESCRIPTION
Would it be better to keep the icon and its styling, even if it's not used anymore ? I splitted the PR in two commits, delete the second one to keep the icon in the project.