### PR TITLE
Update camera, target point positions and cursor height information on exaggeration

### DIFF
--- a/ui/src/cesiumutils.ts
+++ b/ui/src/cesiumutils.ts
@@ -477,7 +477,7 @@ const axisVector3dScratch = new Cartesian3();
  * @param axis configures on which axis second points should be placed (x or y axis according to map rectangle)
  * @param side configures where second point will be placed (left/right or above/below first point)
  */
-export function positionFromPxDistance(scene: Scene, firstPoint: Cartesian3, distancePx: number, axis: 'x' | 'y', side: 1 | -1) {
+export function positionFromPxDistance(scene: Scene, firstPoint: Cartesian3, distancePx: number, axis: 'x' | 'y' | 'z', side: 1 | -1) {
   const mapRect = scene.globe.cartographicLimitRectangle;
   scratchBoundingSphere.center = firstPoint;
   const pixelSize = scene.camera.getPixelSize(scratchBoundingSphere, scene.drawingBufferWidth, scene.drawingBufferHeight);
@@ -485,8 +485,10 @@ export function positionFromPxDistance(scene: Scene, firstPoint: Cartesian3, dis
   let corners;
   if (axis === 'y') {
     corners = [Cartographic.toCartesian(Rectangle.northeast(mapRect)), Cartographic.toCartesian(Rectangle.southeast(mapRect))];
-  } else {
+  } else if (axis === 'x') {
     corners = [Cartographic.toCartesian(Rectangle.northwest(mapRect)), Cartographic.toCartesian(Rectangle.northeast(mapRect))];
+  } else {
+    corners = [firstPoint, updateHeightForCartesianPositions([firstPoint], distance)[0]];
   }
   Cartesian3.midpoint(corners[0], corners[1], scratchPosition);
   const pos = projectPointOnSegment(firstPoint, corners[0], corners[1], 0, 1, 0);

--- a/ui/src/elements/ngm-coordinate-popup.ts
+++ b/ui/src/elements/ngm-coordinate-popup.ts
@@ -35,7 +35,7 @@ export class NgmCoordinatePopup extends LitElementI18n {
                         const cartCoords = Cartographic.fromCartesian(cartesian);
                         this.coordinatesLv95 = formatCartographicAs2DLv95(cartCoords);
                         this.coordinatesWgs84 = [cartCoords.longitude, cartCoords.latitude].map(radToDeg);
-                        this.elevation = this.integerFormat.format(cartCoords.height);
+                        this.elevation = this.integerFormat.format(cartCoords.height / viewer.scene.verticalExaggeration);
                         const altitude = viewer.scene.globe.getHeight(cartCoords) || 0;
                         this.terrainDistance = this.integerFormat.format(Math.abs(cartCoords.height - altitude));
                         this.style.left = event.position.x + 'px';

--- a/ui/src/elements/ngm-cursor-information.ts
+++ b/ui/src/elements/ngm-cursor-information.ts
@@ -61,7 +61,7 @@ export class NgmCursorInformation extends LitElementI18n {
         this.coordinates = formatCartographicAs2DLv95(Cartographic.fromCartesian(cartesian));
         const position = Cartographic.fromCartesian(cartesian);
         const lineOrPolygon = getValueOrUndefined(feature?.id?.polyline?.show) || getValueOrUndefined(feature?.id?.polygon?.show);
-        this.height = position.height;
+        this.height = position.height / this.viewer.scene.verticalExaggeration;
         this.showTerrainHeight = !(feature && !lineOrPolygon);
         return;
       }

--- a/ui/src/elements/ngm-map-configuration.ts
+++ b/ui/src/elements/ngm-map-configuration.ts
@@ -13,6 +13,7 @@ import {
 import type MapChooser from '../MapChooser.js';
 import {debounce} from '../utils';
 import {updateExaggerationForKmlDataSource} from '../cesiumutils';
+import NavToolsStore from '../store/navTools';
 
 @customElement('ngm-map-configuration')
 export class NgmMapConfiguration extends LitElementI18n {
@@ -113,6 +114,7 @@ export class NgmMapConfiguration extends LitElementI18n {
       this.viewer.scene.verticalExaggeration = this.exaggeration;
       this.viewer.scene.requestRender();
       setExaggeration(this.exaggeration);
+      NavToolsStore.exaggerationChanged.next(this.exaggeration);
     }
   }
 

--- a/ui/src/store/navTools.ts
+++ b/ui/src/store/navTools.ts
@@ -8,7 +8,7 @@ export default class NavToolsStore {
   private static hideTargetPointSubject = new Subject<void>();
   private static navLockTypeSubject = new BehaviorSubject<LockType>('');
   private static targetPointPositionSubject = new BehaviorSubject<Cartesian3 | undefined>(undefined);
-
+  static exaggerationChanged = new Subject<number>();
 
   static get syncTargetPoint() {
     return this.syncTargetPointSubject;


### PR DESCRIPTION
- Added a new subject in the store to notify about exaggeration change
- Added calculations to shift the camera and target point on exaggeration change.
- Updated the `positionFromPxDistance` function to calculate z-axis positions too. Before, the z-axis was calculated from the x-axis and was drawn wrong when exaggeration was applied. 
- Height in cursor position information divided on vertical exaggeration to have the same height at a position when exaggeration is applied.