### PR TITLE
Update Rust

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.82 AS build
+FROM rust:1.89 AS build
 
 ARG APP_VERSION
 ENV APP_VERSION=${APP_VERSION}

--- a/api/DockerfileDev
+++ b/api/DockerfileDev
@@ -1,7 +1,7 @@
 # local dev and dev/int/prod images are separate because they
 # are built using a different and incompatible mode (default vs release)
 
-FROM rust:1.82
+FROM rust:1.89
 
 ARG SKIP_TOOLS
 


### PR DESCRIPTION
Had to update Rust because develop had issues with `cargo-watch` requiring `2024`