### PR TITLE
Feature 1725: Layer-Refactoring - Tiff Layer

### DIFF
--- a/TODO_AFTER_LAYER_REFACTORING.md
+++ b/TODO_AFTER_LAYER_REFACTORING.md
@@ -3,3 +3,5 @@
 - re-add zoom to object on permalink (see behavior in old sidebar)
 - reorder pick results by order of layers
 - add 3dtiles v1.1 code to refactored layers (+ attempt to use shader instead of alpha color)
+- discuss background behavior with Nils (terrain remains visible okay?)
+- discuss 3d tiff terrain with Nils (hiding white okay?)

--- a/k8s/templates/ingress-route.yaml
+++ b/k8s/templates/ingress-route.yaml
@@ -23,7 +23,9 @@ spec:
       match: Host(`{{ .Values.api.host }}`) && PathPrefix(`/titiler`)
       priority: 140
       middlewares:
-        - name: {{ .Release.Name }}-titiler-middleware
+        - name: {{ .Release.Name }}-titiler-middleware-strip-prefix
+          namespace: {{ .Release.Namespace }}
+        - name: {{ .Release.Name }}-titiler-middleware-cors
           namespace: {{ .Release.Namespace }}
       services:
         - name: {{ .Release.Name }}-titiler

--- a/k8s/templates/middleware.titiler-cors.yaml
+++ b/k8s/templates/middleware.titiler-cors.yaml
@@ -4,6 +4,5 @@ metadata:
   name: {{ .Release.Name }}-titiler-middleware
   namespace: {{ .Release.Namespace }}
 spec:
-  stripPrefix:
-    prefixes:
-      - /titiler
+  headers:
+    accessControlAllowOrigin: "{{ .Values.ui.host }}"

--- a/k8s/templates/middleware.titiler-strip-prefix.yaml
+++ b/k8s/templates/middleware.titiler-strip-prefix.yaml
@@ -1,0 +1,9 @@
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: {{ .Release.Name }}-titiler-middleware-strip-prefix
+  namespace: {{ .Release.Namespace }}
+spec:
+  stripPrefix:
+    prefixes:
+      - /titiler

--- a/layers/01-maps_and_models.json5
+++ b/layers/01-maps_and_models.json5
@@ -110,7 +110,8 @@
             {
               id: 'lyr_top_bedrock_surface_label',
               children: [
-                "ch.swisstopo.swissbedrock-geotiff"
+                "ch.swisstopo.swissbedrock-geotiff",
+                "ch.swisstopo.swissbedrock-geotiff-with-terrain",
               ]
             }
           ]

--- a/layers/special/swissBEDROCK.json5
+++ b/layers/special/swissBEDROCK.json5
@@ -84,6 +84,96 @@
           display: 'Author',
         }
       ],
+    },
+
+    {
+      // Layer Top Bedrock Geotiff with Terrain
+      type: 'Tiff',
+      id: 'ch.swisstopo.swissbedrock-geotiff-with-terrain',
+      url: 'https://download.swissgeol.ch/swissbedrock/release_01/swissBEDROCK_R1.tif',
+      terrain: {
+        type: "CesiumIon",
+        asset_id: 3914142,
+      },
+      opacity: 0.5,
+      download_url: {
+        de: 'https://www.swisstopo.admin.ch/de/swissbedrock-de',
+        en: 'https://www.swisstopo.admin.ch/en/swissbedrock-en',
+        fr: 'https://www.swisstopo.admin.ch/fr/swissbedrock-fr',
+        it: 'https://www.swisstopo.admin.ch/it/swissbedrock-it',
+      },
+      geocat_id: 'f7836146-3f9a-4807-9011-618800409236',
+      cell_size: 10,
+      bands: [
+        {
+          index: 1,
+          name: 'BEM',
+          unit: 'MetersAboveSeaLevel',
+          display: 'BEM',
+        },
+        {
+          index: 2,
+          name: 'TMUD',
+          unit: 'Meters',
+          display: 'TMUD',
+        },
+        {
+          index: 3,
+          name: 'Uncertainty',
+          unit: 'Meters',
+          display: 'Uncertainty'
+        },
+        {
+          index: 4,
+          name: 'Version',
+          display: {
+            bounds: [221104, 250519],
+            color_map: 'swissBEDROCK_Version',
+            is_discrete: true,
+          },
+        },
+        {
+          index: 5,
+          name: 'Author',
+          display: 'Author',
+        },
+        {
+          index: 6,
+          name: 'Change',
+          unit: 'Meters',
+          display: {
+            bounds: [-30, 30],
+            color_map: 'swissBEDROCK_Change'
+          },
+        },
+        {
+          index: 7,
+          name: 'prev_BEM',
+          unit: 'MetersAboveSeaLevel',
+          display: 'BEM'
+        },
+        {
+          index: 8,
+          name: 'prev_TMUD',
+          unit: 'Meters',
+          display: 'TMUD',
+        },
+        {
+          index: 9,
+          name: 'prev_Uncertainty',
+          unit: 'Meters',
+          display: 'Uncertainty',
+        },
+        {
+          index: 10,
+          name: 'prev_Version',
+        },
+        {
+          index: 11,
+          name: 'prev_Author',
+          display: 'Author',
+        }
+      ],
     }
   ],
   'tiff_displays': {

--- a/ui/locales/layers/layers.de.json
+++ b/ui/locales/layers/layers.de.json
@@ -6,22 +6,6 @@
     "title": "Info",
     "zoomToObject": "Auf Objekt zoomen"
   },
-  "swissBEDROCK": {
-    "title": "swissBEDROCK",
-    "bands": {
-      "BEM": "Höhenmodell der Felsoberfläche",
-      "TMUD": "Mächtigkeitsmodell des Lockergesteins",
-      "Uncertainty": "Unsicherheit",
-      "Version": "Versionsnummer",
-      "Author": "Numerische Autoren-ID",
-      "Change": "Änderung zur vorherigen Version",
-      "prev_BEM": "Vorherige Version des Höhenmodells der Felsoberfläche",
-      "prev_TMUD": "Vorherige Version des Mächtigkeitsmodells des Lockergesteins",
-      "prev_Uncertainty": "Vorherige Version der Unsicherheit",
-      "prev_Version": "Vorherige Versionsnummer",
-      "prev_Author": "Vorherige Version – numerische Autoren-ID"
-    }
-  },
   "units": {
     "Meters": {
       "name": "Meter",
@@ -33,7 +17,8 @@
     }
   },
   "layers": {
-    "ch.swisstopo.geologie-geocover": "GeoCover - Vektordaten"
+    "ch.swisstopo.geologie-geocover": "GeoCover - Vektordaten",
+    "ch.swisstopo.swissbedrock-geotiff": "swissBEDROCK"
   },
   "groups": {
     "grp_1786_label": "Karten, Profile & Modelle",
@@ -60,6 +45,19 @@
       "logk": "Hydraulische Leitfähigkeit",
       "Index": "Modelliereinheit",
       "Klasse": "Durchlässigkeit"
+    },
+    "ch.swisstopo.swissbedrock-geotiff": {
+      "BEM": "Höhenmodell der Felsoberfläche",
+      "TMUD": "Mächtigkeitsmodell des Lockergesteins",
+      "Uncertainty": "Unsicherheit",
+      "Version": "Versionsnummer",
+      "Author": "Numerische Autoren-ID",
+      "Change": "Änderung zur vorherigen Version",
+      "prev_BEM": "Vorherige Version des Höhenmodells der Felsoberfläche",
+      "prev_TMUD": "Vorherige Version des Mächtigkeitsmodells des Lockergesteins",
+      "prev_Uncertainty": "Vorherige Version der Unsicherheit",
+      "prev_Version": "Vorherige Versionsnummer",
+      "prev_Author": "Vorherige Version – numerische Autoren-ID"
     }
   },
   "values": {

--- a/ui/src/features/catalog/catalog.module.ts
+++ b/ui/src/features/catalog/catalog.module.ts
@@ -2,6 +2,8 @@ import './display/catalog-display-list.element';
 import './display/catalog-display-list-item.element';
 import './display/details/catalog-display-legend-detail.element';
 import './display/details/catalog-display-times-detail.element';
+import './display/details/catalog-display-tiff-bands.element';
+import './display/details/catalog-display-tiff-legend.element';
 import './display/details/catalog-display-voxel-filter-detail.element';
 
 import './tree/catalog-tree.element';

--- a/ui/src/features/catalog/display/catalog-display-list-item.element.ts
+++ b/ui/src/features/catalog/display/catalog-display-list-item.element.ts
@@ -145,7 +145,9 @@ export class CatalogDisplayList extends CoreElement {
     this.openWindow('tiffFilter', {
       title: () => getLayerLabel(this.layer),
       body: () => html`
-        <ngm-layer-tiff-bands .layer="${this.layer}"></ngm-layer-tiff-bands>
+        <catalog-display-layer-tiff-bands
+          .layerId=${this.layer.id}
+        ></catalog-display-layer-tiff-bands>
       `,
     });
 

--- a/ui/src/features/layer/info/pickers/layer-info-picker-for-tiff.ts
+++ b/ui/src/features/layer/info/pickers/layer-info-picker-for-tiff.ts
@@ -3,56 +3,61 @@ import {
   LayerPickData,
 } from 'src/features/layer/info/pickers/layer-info-picker';
 import {
+  Cartesian3,
   Cartographic,
   Color,
+  ColorMaterialProperty,
   Ellipsoid,
   EllipsoidGeodesic,
   Entity,
   HeightReference,
+  JulianDate,
   Math as CesiumMath,
   PolygonHierarchy,
+  Resource,
   Viewer,
-  ColorMaterialProperty,
-  Cartesian3,
-  JulianDate,
 } from 'cesium';
-import { LayerTiffController, PickData } from 'src/features/layer';
+import { TiffLayer } from 'src/features/layer';
 import i18next from 'i18next';
 import {
   LayerInfo,
   LayerInfoAttribute,
 } from 'src/features/layer/info/layer-info.model';
-import { OBJECT_HIGHLIGHT_COLOR } from 'src/constants';
+import { OBJECT_HIGHLIGHT_COLOR, TITILER_BY_PAGE_HOST } from 'src/constants';
+import { TiffLayerController } from 'src/features/layer/new/controllers/layer-tiff.controller';
+import { Id } from 'src/models/id.model';
+import proj4 from 'proj4';
 
 const DEFAULT_COLOR = Color.fromBytes(120, 255, 52, Math.round(0.6 * 255));
 
 export class LayerInfoPickerForTiff implements LayerInfoPicker {
+  private metadata!: TiffMetadata;
+
   constructor(
+    private readonly controller: TiffLayerController,
     private readonly viewer: Viewer,
-    private readonly controller: LayerTiffController,
   ) {}
 
-  get source(): LayerTiffController {
-    return this.controller;
+  get source(): Id<TiffLayer> {
+    return this.controller.layer.id;
   }
 
   async pick(pick: LayerPickData): Promise<LayerInfo[]> {
-    if (!this.controller.layer.visible) {
+    if (!this.controller.layer.isVisible) {
       return [];
     }
-    const data = await this.controller.pick(pick.globePosition.cartographic);
+    this.metadata ??= await this.fetchMetadata();
+    const data = await this.pickViaService(pick.globePosition.cartographic);
     if (data === null) {
       return [];
     }
     const { layer } = this.controller;
     const attributes = this.controller.layer.bands.map((band) => {
       return {
-        get key(): string {
-          return i18next.t(`layers:${layer.id}.bands.${band.name}`);
-        },
+        key: `layers:attributes.${layer.id}.${band.name}`,
         get value(): string | number {
           return (
-            data.bands[band.index - 1] ?? i18next.t('layers:geoTIFF.noData')
+            data.bands[band.index - 1] ?? i18next.t('layers:values.noData')
           );
         },
       };
@@ -61,12 +66,107 @@ export class LayerInfoPickerForTiff implements LayerInfoPicker {
       new LayerInfoForTiff(this.viewer, {
         entity: this.createHighlight(data),
         source: this.source,
-        get title(): string {
-          return i18next.t(layer.label);
-        },
+        title: `layers:layers.${this.controller.layer.id}`,
         attributes,
       }),
     ];
+  }
+
+  private async pickViaService(coords: Cartographic): Promise<PickData | null> {
+    const longitude = CesiumMath.toDegrees(coords.longitude);
+    const latitude = CesiumMath.toDegrees(coords.latitude);
+
+    interface Json {
+      coordinates: [number, number];
+      values: Array<number | null>;
+      band_names: string[];
+    }
+
+    const { layer } = this.controller;
+    const url = `${TITILER_BY_PAGE_HOST[window.location.host]}/cog/point/${longitude},${latitude}?url=${layer.url}`;
+    const json: Json = await Resource.fetchJson({ url });
+    try {
+      const activeBandIndex = layer.bands[layer.bandIndex].index;
+      const activeValue = json.values[activeBandIndex - 1];
+      if (activeValue === null) {
+        return null;
+      }
+      const [cellLongitude, cellLatitude] = this.computeCellCenter(
+        longitude,
+        latitude,
+      );
+      return {
+        coordinates: Cartesian3.fromDegrees(
+          cellLongitude,
+          cellLatitude,
+          coords.height,
+        ),
+        bands: json.values,
+      };
+    } catch (e) {
+      console.error(`failed to pick TIFF ${this.source}`, e);
+      return null;
+    }
+  }
+
+  /**
+   * Given a 2d coordinate, this method calculates in which of the TIFF's cells that coordinate falls.
+   *
+   * @param lon The coordinate's longitude.
+   * @param lat The coordinate's latitude.
+   * @return The center longitude/latitude of the cell that contains the given coordinates.
+   *
+   * @private
+   */
+  private computeCellCenter(lon: number, lat: number): [number, number] {
+    const wgs84 = 'EPSG:4326';
+
+    const [x, y] = proj4(wgs84, this.metadata.crs, [lon, lat]);
+
+    const [originX, _y, _x, originY] = this.metadata.bounds;
+    const [cellWidth, cellHeight] = this.metadata.cellDimension;
+
+    const px = Math.floor((x - originX) / cellWidth);
+    const py = Math.floor((y - originY) / cellHeight);
+
+    const centerPx = px;
+    const centerPy = py;
+
+    const centerX = cellWidth * centerPx + originX + cellWidth / 2;
+    const centerY = cellHeight * centerPy + originY + cellHeight / 2;
+
+    const [centerLon, centerLat] = proj4(this.metadata.crs, wgs84, [
+      centerX,
+      centerY,
+    ]);
+
+    return [centerLon, centerLat];
+  }
+
+  private async fetchMetadata(): Promise<TiffMetadata> {
+    interface Json {
+      bounds: [number, number, number, number];
+      crs: `http://www.opengis.net/def/crs/EPSG/0/${number}`;
+      width: number;
+      height: number;
+    }
+
+    const url = `${TITILER_BY_PAGE_HOST[window.location.host]}/cog/info?url=${this.controller.layer.url}`;
+    const json: Json = await Resource.fetchJson({ url });
+
+    const [minX, minY, maxX, maxY] = json.bounds;
+    const widthInCrs = maxX - minX;
+    const heightInCrs = maxY - minY;
+
+    const cellWidth = widthInCrs / json.width;
+    const cellHeight = heightInCrs / json.height;
+
+    return {
+      bounds: json.bounds,
+      crs: `EPSG:${json.crs.slice(json.crs.lastIndexOf('/') + 1)}`,
+      dimension: [json.width, json.height],
+      cellDimension: [cellWidth, cellHeight],
+    };
   }
 
   private createHighlight(data: PickData): Entity {
@@ -100,7 +200,7 @@ export class LayerInfoPickerForTiff implements LayerInfoPicker {
       );
     }
 
-    const offset = data.layer.metadata.cellSize / 2;
+    const offset = this.controller.layer.cellSize / 2;
 
     // Calculate corners of a 10x10 rectangle, adjusted for the current projection.
     const positions = [
@@ -125,7 +225,7 @@ export class LayerInfoPickerForTiff implements LayerInfoPicker {
 }
 
 class LayerInfoForTiff implements LayerInfo {
-  public readonly source: LayerTiffController;
+  public readonly source: Id<TiffLayer>;
   public readonly title: string;
   public readonly attributes: LayerInfoAttribute[];
   private readonly entity: Entity;
@@ -134,7 +234,7 @@ class LayerInfoForTiff implements LayerInfo {
     private readonly viewer: Viewer,
     data: Pick<LayerInfo, 'source' | 'title' | 'attributes'> & {
       entity: Entity;
-      source: LayerTiffController;
+      source: Id<TiffLayer>;
     },
   ) {
     this.entity = data.entity;
@@ -170,4 +270,32 @@ class LayerInfoForTiff implements LayerInfo {
   destroy(): void {
     this.viewer.entities.remove(this.entity);
   }
+}
+
+interface PickData {
+  coordinates: Cartesian3;
+  bands: Array<number | null>;
+}
+
+interface TiffMetadata {
+  /**
+   * The TIFF's coordinate system (e.g. "EPSG:4326").
+   */
+  crs: string;
+
+  /**
+   * The TIFF's bounding rectangle in the format `[minX, minY, maxX, maxY]`.
+   * The units correspond to the TIFF's {@link crs coordinate system}.
+   */
+  bounds: [number, number, number, number];
+
+  /**
+   * The amount of cells (i.e. pixels) the TIFF contains on its x- and y-axis, respectively.
+   */
+  dimension: [number, number];
+
+  /**
+   * The size of each of the TIFF's cells (i.e. pixels) inside the TIFF's {@link crs coordinate system}.
+   */
+  cellDimension: [number, number];
 }

--- a/ui/src/features/layer/layer.module.ts
+++ b/ui/src/features/layer/layer.module.ts
@@ -3,6 +3,3 @@ import './background/background-layer-select.element';
 
 import './info/layer-info-item.element';
 import './info/layer-info-list.element';
-
-import './tiff/layer-tiff-bands.element';
-import './tiff/layer-tiff-legend.element';

--- a/ui/src/features/layer/models/layer-tiff.model.ts
+++ b/ui/src/features/layer/models/layer-tiff.model.ts
@@ -1,4 +1,5 @@
 import { BaseLayer, LayerType } from './layer.model';
+import { LayerSource } from 'src/features/layer';
 
 export interface TiffLayer extends BaseLayer {
   type: LayerType.Tiff;
@@ -9,9 +10,20 @@ export interface TiffLayer extends BaseLayer {
   url: string;
 
   /**
+   * The source for the layer's terrain.
+   * If this is `null`, the TIFF is draped directly onto the default terrain.
+   */
+  terrain: LayerSource | null;
+
+  /**
    * The width and height of each of the TIFF's cells, in meters.
    */
   cellSize: number;
+
+  /**
+   * The index of the visible band.
+   */
+  bandIndex: number;
 
   /**
    * The tiff's bands.
@@ -48,11 +60,14 @@ export interface TiffLayerConfigDisplay {
    *
    * This configuration is used mainly for calculating the band's legend and tooltips.
    * Values in the band may fall outside of this range without causing any issue.
-   *
-   * If the layer's legend should be rendered in descending order,
-   * the lower and upper bound are switched.
    */
   bounds: [number, number];
+
+  /**
+   * The order in which the bounds should be rendered on the layer's legend.
+   * `asc` goes from min to max, `desc` is reversed.
+   */
+  direction: 'asc' | 'desc';
 
   /**
    * The value that represents the absence of data on this band.

--- a/ui/src/features/layer/models/layer-tiles3d.model.ts
+++ b/ui/src/features/layer/models/layer-tiles3d.model.ts
@@ -13,4 +13,10 @@ export interface Tiles3dLayer extends BaseLayer {
    * Keys that are left out will be sorted below any sorted ones, in default order.
    */
   orderOfProperties: string[];
+
+  /**
+   * Whether the layer is partially transparent.
+   * For partially transparent tiles, fragments that are fully white are discarded.
+   */
+  isPartiallyTransparent: boolean;
 }

--- a/ui/src/features/layer/new/controllers/layer-background.controller.ts
+++ b/ui/src/features/layer/new/controllers/layer-background.controller.ts
@@ -34,31 +34,27 @@ export class BackgroundLayerController extends BaseLayerController<BackgroundLay
     // - panning works as expected, as the cursor can "grab" onto the globe.
     // - The opacity and visibility of imageries stay independent of the background.
     this.watch(this.layer.isVisible, (isVisible) => {
-      if (isVisible) {
-        this.children.forEach((child) =>
-          child.update({ ...child.layer, isVisible: true, opacity: 1 }),
-        );
-      } else {
-        this.children.forEach((child) =>
-          child.update({ ...child.layer, isVisible: false, opacity: 0 }),
-        );
-      }
+      this.setLayerOpacity(isVisible ? this.layer.opacity : 0);
     });
   }
 
   private setLayerOpacity(opacity: number): void {
     const { translucency } = this.viewer.scene.globe;
+    const isVisible = opacity > 0;
+    this.children.forEach((child) =>
+      child.update({ ...child.layer, isVisible, opacity }),
+    );
     if (opacity === 1) {
       translucency.enabled = false;
-      translucency.frontFaceAlphaByDistance = undefined as any;
+      // translucency.frontFaceAlphaByDistance = undefined as any;
     } else {
       translucency.enabled = true;
-      translucency.frontFaceAlphaByDistance = new Cesium.NearFarScalar(
-        1.0,
-        opacity, // near, alpha
-        1.0e7,
-        opacity, // far, alpha
-      );
+      // translucency.frontFaceAlphaByDistance = new Cesium.NearFarScalar(
+      //   1.0,
+      //   opacity, // near, alpha
+      //   1.0e7,
+      //   opacity, // far, alpha
+      // );
     }
   }
 
@@ -109,6 +105,8 @@ export class BackgroundLayerController extends BaseLayerController<BackgroundLay
         viewer.scene.imageryLayers.raiseToTop(imagery);
       }
     }
+
+    this.setLayerOpacity(layer.isVisible ? layer.opacity : 0);
   }
 
   protected removeFromViewer(): void {

--- a/ui/src/features/layer/new/controllers/layer-tiff.controller.ts
+++ b/ui/src/features/layer/new/controllers/layer-tiff.controller.ts
@@ -1,0 +1,187 @@
+import { BaseLayerController } from 'src/features/layer/new/controllers/layer.controller';
+import {
+  LayerType,
+  TiffLayer,
+  Tiles3dLayer,
+  WmtsLayer,
+  WmtsLayerSource,
+} from 'src/features/layer';
+import { UrlTemplateImageryProvider, WebMercatorTilingScheme } from 'cesium';
+import { SWITZERLAND_RECTANGLE, TITILER_BY_PAGE_HOST } from 'src/constants';
+import { Tiles3dLayerController } from 'src/features/layer/new/controllers/layer-tiles3d.controller';
+import { makeId } from 'src/models/id.model';
+import {
+  WmtsImageryProvider,
+  WmtsLayerController,
+} from 'src/features/layer/new/controllers/layer-wmts.controller';
+
+// TODO remove this
+export class TiffLayerController extends BaseLayerController<TiffLayer> {
+  /**
+   * The controller responsible for displaying the tiff's active band.
+   *
+   * If {@link terrainController} exists, the bands are rendered on top of it.
+   * Otherwise, they are draped directly onto the base terrain.
+   * @private
+   */
+  private bandController!: WmtsLayerController;
+
+  /**
+   * The controller responsible for displaying the tiff's terrain.
+   *
+   * For tiffs without a {@link TiffLayer.terrain terrain}, this is `null`.
+   * @private
+   */
+  private terrainController!: Tiles3dLayerController | null;
+
+  get type(): LayerType.Tiff {
+    return LayerType.Tiff;
+  }
+
+  /**
+   * The main controller, i.e. the one that is directly added to the viewer.
+   * @private
+   */
+  private get controller(): WmtsLayerController | Tiles3dLayerController {
+    return this.terrainController ?? this.bandController;
+  }
+
+  zoomIntoView(): void {
+    this.controller.zoomIntoView();
+  }
+
+  moveToTop(): void {
+    this.controller.moveToTop();
+  }
+
+  protected reactToChanges(): void {
+    // Don't watch anything, as we handle changes in the child controllers.
+  }
+
+  async update(layer: TiffLayer): Promise<void> {
+    await super.update(layer);
+
+    await this.terrainController?.update(this.makeTiles3dLayer());
+    await this.bandController?.update(this.makeWmtsLayer());
+  }
+
+  protected async addToViewer(): Promise<void> {
+    this.terrainController = this.layer.terrain && this.makeTerrainController();
+    await this.terrainController?.add();
+
+    this.bandController ??= this.makeBandController();
+    await this.bandController.add();
+  }
+
+  protected removeFromViewer(): void {
+    this.controller.remove();
+  }
+
+  private makeBandController(): WmtsLayerController {
+    // A getter for the current layer for use within the layer controller.
+    // This allows the inner controller to access the most recent version of our model at any time.
+    const getLayer = () => this.layer;
+
+    // A subclass of `WmtsLayerController` that loads tiff data from TiTiler.
+    class CustomWmtsController extends WmtsLayerController {
+      protected override reactToChanges(): void {
+        super.reactToChanges();
+
+        // Reinitialize the layer when the band index changes.
+        const layer = getLayer();
+        this.watch(layer.bandIndex);
+      }
+
+      protected override makeProvider(): WmtsImageryProvider {
+        const layer = getLayer();
+        const band = layer.bands[layer.bandIndex];
+        const noDataParam =
+          band.display?.noData === null ? '' : '&nodata={nodata}';
+        const rescaleParam = band.display?.isDiscrete
+          ? ''
+          : '&rescale={min},{max}';
+        const provider = new UrlTemplateImageryProvider({
+          url: `${TITILER_BY_PAGE_HOST[window.location.host]}/cog/tiles/WebMercatorQuad/{z}/{x}/{y}.png?url={url}&bidx={bidx}&colormap_name={colormap}${rescaleParam}${noDataParam}`,
+          customTags: {
+            url: () => layer.url,
+            bidx: () => band.index,
+            colormap: () => band.display!.colorMap,
+            min: () => band.display!.bounds[0],
+            max: () => band.display!.bounds[1],
+            nodata: () => band.display!.noData,
+          },
+          rectangle: SWITZERLAND_RECTANGLE,
+          tilingScheme: new WebMercatorTilingScheme(),
+          enablePickFeatures: true,
+          hasAlphaChannel: true,
+        });
+        provider.errorEvent.addEventListener(() => {
+          // Suppress error logs
+        });
+        return provider;
+      }
+    }
+
+    const wmtsLayer = this.makeWmtsLayer();
+    return this.terrainController === null
+      ? // If there is no custom terrain, we add the band directly to the viewer.
+        new CustomWmtsController(wmtsLayer)
+      : // If there is a custom terrain, we drape the band on top of it.
+        new CustomWmtsController(
+          wmtsLayer,
+          this.terrainController.tileset.imageryLayers,
+        );
+  }
+
+  private makeTerrainController(): Tiles3dLayerController {
+    return new Tiles3dLayerController(this.makeTiles3dLayer());
+  }
+
+  private makeTiles3dLayer(): Tiles3dLayer {
+    return {
+      type: LayerType.Tiles3d,
+      id: makeId(this.layer.id),
+      source: this.layer.terrain!,
+      isVisible: this.layer.isVisible,
+      opacity: this.layer.opacity,
+      canUpdateOpacity: true,
+      downloadUrl: null,
+      geocatId: null,
+      label: null,
+      legend: null,
+      orderOfProperties: [],
+
+      // Make the layer partially transparent to hide parts that are not covered by the imagery.
+      isPartiallyTransparent: true,
+    };
+  }
+
+  private makeWmtsLayer(): WmtsLayer {
+    // Check if the band layers are standalone, i.e. added directly to the viewer.
+    const isStandalone = this.terrainController === null;
+    return {
+      type: LayerType.Wmts,
+
+      // These don't actually matter all that much compared to normal WMTS layers,
+      // as we create a custom provider that doesn't rely on them.
+      id: makeId(this.layer.id),
+      source: WmtsLayerSource.WMTS,
+      format: '',
+      credit: '',
+      maxLevel: null,
+
+      // These don't matter, as they are never exposed to anyone outside of this controller.
+      times: null,
+      label: null,
+      geocatId: null,
+      downloadUrl: null,
+      legend: null,
+
+      // Standalone bands inherit the opacity and visibility of the tiff.
+      // Non-standalone bands have these at static values, as they are set on the terrain.
+      opacity: isStandalone ? this.layer.opacity : 1,
+      canUpdateOpacity: isStandalone,
+      isVisible: isStandalone ? this.layer.isVisible : true,
+    };
+  }
+}

--- a/ui/src/features/layer/new/controllers/layer-voxel.controller.ts
+++ b/ui/src/features/layer/new/controllers/layer-voxel.controller.ts
@@ -105,7 +105,7 @@ export class VoxelLayerController extends BaseLayerController<VoxelLayer> {
     // These are important to be sorted the same, always,
     // as we use a key's index to communicate its state to the layer's shader.
     this.knownKeys = this.layer.mappings.map((it) => it.key);
-    this.knownKeys.sort();
+    this.knownKeys.sort((a, b) => a.localeCompare(b));
 
     // Our shader uses its key's index within `knownKeys` as identifier.
     // This means that there needs to be a 1:1 relation between keys and mappings.

--- a/ui/src/features/layer/new/layer.service.ts
+++ b/ui/src/features/layer/new/layer.service.ts
@@ -43,6 +43,7 @@ import MainStore from 'src/store/main';
 import { Tiles3dLayerController } from 'src/features/layer/new/controllers/layer-tiles3d.controller';
 import { BackgroundLayerController } from 'src/features/layer/new/controllers/layer-background.controller';
 import { VoxelLayerController } from 'src/features/layer/new/controllers/layer-voxel.controller';
+import { TiffLayerController } from 'src/features/layer/new/controllers/layer-tiff.controller';
 
 export class LayerService extends BaseService {
   private viewer!: Viewer;
@@ -805,7 +806,7 @@ export class LayerService extends BaseService {
       case LayerType.Voxel:
         return new VoxelLayerController(layer);
       case LayerType.Tiff:
-        throw new Error('nyi');
+        return new TiffLayerController(layer);
     }
   }
 

--- a/ui/src/services/pick.service.ts
+++ b/ui/src/services/pick.service.ts
@@ -12,6 +12,8 @@ import MainStore from 'src/store/main';
 export class PickService extends BaseService {
   private viewer: Viewer | null = null;
 
+  private disableCount = 0;
+
   constructor() {
     super();
     MainStore.viewer.subscribe((viewer) => {
@@ -19,19 +21,95 @@ export class PickService extends BaseService {
     });
   }
 
-  pick(position: Cartesian2): Cartesian3 | null {
+  /**
+   * Find the position on the map that is displayed at a specific window coordinate.
+   *
+   * @param windowPosition The position on the window.
+   * @return the corresponding world position.
+   */
+  pick(windowPosition: Cartesian2): Cartesian3 | null {
     if (this.viewer === null) {
       return null;
     }
+    if (
+      this.disableCount === 0 &&
+      this.viewer.scene.pickPositionSupported &&
+      this.viewer.scene.globe.show
+    ) {
+      return this.tryPickWithSceneOrFallback(windowPosition);
+    } else {
+      return this.pickWithMath(windowPosition);
+    }
+  }
 
+  private pickWithScene(position: Cartesian2): Cartesian3 | null {
+    return this.viewer!.scene.pickPosition(position) ?? null;
+  }
+
+  private tryPickWithSceneOrFallback(position: Cartesian2): Cartesian3 | null {
+    try {
+      return this.pickWithScene(Cartesian2.clone(position));
+    } catch (e) {
+      if (!String(e).startsWith('DeveloperError: This object was destroyed,')) {
+        throw e;
+      }
+      return this.pickWithMath(position);
+    }
+  }
+
+  private pickWithMath(position: Cartesian2): Cartesian3 | null {
     // Determine the position of the click on the globe via a ray cast onto the WGS ellipsoid.
     // This method works even with the globe turned off, unlike `scene.pickPosition`.
     // It also doesn't trigger any weird errors happening around picking while specific tiles aren't fully loaded yet.
-    const ray = this.viewer.camera.getPickRay(position);
+    // However, it may not be as accurate as `scene.pickPosition`,
+    // especially in regard to specific positions on elevated or sunken terrain.
+    const ray = this.viewer!.camera.getPickRay(position);
     if (ray === undefined) {
       return null;
     }
     const interval = IntersectionTests.rayEllipsoid(ray, Ellipsoid.WGS84);
+    if (interval === undefined) {
+      return null;
+    }
     return Ray.getPoint(ray, interval.start);
   }
+
+  /**
+   * Acquire a {@link ScenePickingLock} that, while active, disables the use of `Scene.pickPosition`.
+   * This is useful as that method can cause unrecoverable render issues when called
+   * while some layers, tiles or other primitives are not yet fully loaded.
+   *
+   * Note that it's the responsibility of the caller to fully release the lock.
+   * When not explicitly releasing a lock, `Scene.pickPosition` will remain unused,
+   * possibly leading to inaccurate pick behavior.
+   */
+  acquireScenePickingLock(): ScenePickingLock {
+    this.disableCount += 1;
+    let isActive = true;
+    return {
+      release: (): void => {
+        if (isActive) {
+          this.disableCount = Math.max(0, this.disableCount - 1);
+          isActive = false;
+        }
+      },
+    };
+  }
+}
+
+/**
+ * A lock that, while active, disables accurate picking using the Cesium scene.
+ *
+ * It is the callers responsibility to ensure that locks are released before they are destroyed.
+ *
+ * Note that multiple locks can exist at the same time, without influencing each other.
+ * Releasing a lock while another remains will leave pick behavior locked.
+ */
+export interface ScenePickingLock {
+  /**
+   * Releases the lock, allowing `Scene.pickPosition` to be used.
+   *
+   * This method may be called multiple times without consequences.
+   */
+  release(): void;
 }


### PR DESCRIPTION
Resolves #1725.
Part of #1587.
Depends on #1724.

Implements the display and controls of tiff layers. Also:

- Adds the ability to specify a 3d terrain for tiffs, onto which the bands are then draped (taken from #1735).
- Updates the 3dtiles controller to neatly integrate with the tiff controller.
- Adds CORS to the TiTiler deployment.

Note that you need a custom Cesium Ion Access Token for testing the 3d tiff terrain.
