### PR TITLE
Instead of copying the file, get from temp and put it on permanent

### DIFF
--- a/api/src/handlers.rs
+++ b/api/src/handlers.rs
@@ -552,11 +552,19 @@ async fn save_assets(client: Client, project_assets: &Vec<Asset>) {
             .is_ok();
 
         if source_exists && !destination_exists {
-            client
-                .copy_object()
+            let obj = client
+                .get_object()
                 .bucket(&bucket)
-                .copy_source(format!("{}/{}", &bucket, &temp_key))
+                .key(&temp_key)
+                .send()
+                .await
+                .unwrap();
+
+            client
+                .put_object()
+                .bucket(&bucket)
                 .key(&permanent_key)
+                .body(obj.body)
                 .send()
                 .await
                 .unwrap();


### PR DESCRIPTION
resolves #1712 
To avoid the `AccessDenied: not authorized for s3:PutObjectTagging` error, I instead put the file to the permanent location instead of copying