### PR TITLE
Add access control to layerGroups

### DIFF
--- a/api/src/layers/group.rs
+++ b/api/src/layers/group.rs
@@ -1,3 +1,4 @@
+use crate::layers::access::LayerAccess;
 use crate::layers::config::{Parse, ParseContext};
 use anyhow::anyhow;
 use serde::de::Error;
@@ -19,6 +20,11 @@ pub struct LayerGroup {
     /// or not a top level group, this field will never be used.
     #[serde(skip, default)]
     pub use_count: u32,
+
+    /// A JSON object defining who has access to this layer.
+    /// If left out, the layer is publicly available.
+    #[serde(default, skip_serializing)]
+    pub access: Option<LayerAccess>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/layers/layertree.json5
+++ b/layers/layertree.json5
@@ -6,7 +6,6 @@
     'special/swissBEDROCK',
     'layers_earthquakes'
   ],
-
   groups: [
     // 01 Topic - Maps, cross-sections & models
     {
@@ -34,14 +33,14 @@
             'ch.swisstopo.geologie-gletschermaechtigkeit',
             'ch.swisstopo.geologie-gletscherausdehnung',
             'ch.swisstopo.geologie-geomorphologie'
-        ]
+          ]
         },
         // 02 - Historic_maps
         {
           id: 'historic_maps',
           children: [
             'ch.swisstopo.geologie-generalkarte-ggk200'
-        ]
+          ]
         },
         // 02 - Sheet divisions
         {
@@ -52,7 +51,7 @@
             'ch.swisstopo.geologie-spezialkarten_schweiz_vector.metadata',
             'ch.swisstopo.geologie-geologischer_atlas.metadata',
             'ch.swisstopo.geologie-geocover.metadata'
-        ]
+          ]
         },
         // 02 - Cross-sections
         {
@@ -61,7 +60,7 @@
             'ch.swisstopo.geologie-geologischer_atlas_profile',
             'geomol_cs',
             'geoquat_aaretal_cs'
-        ]
+          ]
         },
         // 02 - 3D models
         {
@@ -280,22 +279,22 @@
         'ch.bafu.hydrogeologische-karte_100',
         'ch.bafu.grundwasserkoerper',
         // 02 Topic - Groundwater quantity
-      {
-        id: 'groundwater_quantity',
-        children: [
-          'ch.bafu.hydroweb-messstationen_grundwasser',
-          'ch.bafu.hydroweb-messstationen_grundwasserzustand'
-        ]
-      },
-      'ch.bafu.hydrogeologie-markierversuche',
-      // 02 Topic - Groundwater quality
-      {
-        id: 'groundwater_quality',
-        children: [
-          'ch.bafu.naqua-grundwasser_nitrat',
-          'ch.bafu.naqua-grundwasser_voc'
-        ]
-      }
+        {
+          id: 'groundwater_quantity',
+          children: [
+            'ch.bafu.hydroweb-messstationen_grundwasser',
+            'ch.bafu.hydroweb-messstationen_grundwasserzustand'
+          ]
+        },
+        'ch.bafu.hydrogeologie-markierversuche',
+        // 02 Topic - Groundwater quality
+        {
+          id: 'groundwater_quality',
+          children: [
+            'ch.bafu.naqua-grundwasser_nitrat',
+            'ch.bafu.naqua-grundwasser_voc'
+          ]
+        }
       ]
     },
     // 01 Topic - Natural hazards
@@ -368,7 +367,6 @@
             'ch.swisstopo.geologie-geotope_kantone_stand'
           ]
         },
-
       ]
     },
     // 01 Topic - Underground space


### PR DESCRIPTION
Resolves #1766 
Allows groups to be only visible for authorized users or in certain environments
Extends the `LayerGroup `struct with the `access `property and filters the groups by access.
A second run over the `layers `filters all layers that are in no group