### PR TITLE
Feature/viewer 1758 ogc integration stac

### DIFF
--- a/api/src/layers/source.rs
+++ b/api/src/layers/source.rs
@@ -51,9 +51,7 @@ pub enum OgcSource {
     },
 
     #[serde(rename = "stac", rename_all(serialize = "camelCase"))]
-    Stac {
-        collection: String,
-    },
+    Stac { collection: String },
 
     #[serde(rename = "fdsn", rename_all(serialize = "camelCase"))]
     Fdsn {
@@ -65,5 +63,3 @@ pub enum OgcSource {
         // WMS-spezifische Felder
     },
 }
-
-

--- a/api/src/layers/source.rs
+++ b/api/src/layers/source.rs
@@ -25,18 +25,45 @@ pub enum LayerSource {
     },
 
     #[serde(rename_all(serialize = "camelCase"))]
-    Ogc {
-        /// The id of the collection representing the layer.
+    Ogc(OgcLayerSource),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all(serialize = "camelCase"))]
+pub struct OgcLayerSource {
+    pub ogc_source: OgcSource,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub display_source: Option<Box<LayerSource>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum OgcSource {
+    #[serde(rename = "gst", rename_all(serialize = "camelCase"))]
+    Gst {
         id: u32,
 
         /// The id of the style with which the layer should be rendered.
         /// If left out, the collection's default download is used.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         style_id: Option<u32>,
+    },
 
-        /// An optional source that will be used when displaying the layer.
-        /// When this is set, the OGC API will only be used for layer exports.
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        display_source: Option<Box<LayerSource>>,
+    #[serde(rename = "stac", rename_all(serialize = "camelCase"))]
+    Stac {
+        collection: String,
+    },
+
+    #[serde(rename = "fdsn", rename_all(serialize = "camelCase"))]
+    Fdsn {
+        // FDSN-spezifische Felder
+    },
+
+    #[serde(rename = "wms", rename_all(serialize = "camelCase"))]
+    Wms {
+        // WMS-spezifische Felder
     },
 }
+
+

--- a/api/src/layers/wmts.rs
+++ b/api/src/layers/wmts.rs
@@ -1,3 +1,4 @@
+use crate::OgcSource;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -7,4 +8,7 @@ pub struct WmtsLayer {
     /// Instead, this level's tiles will be scaled up to fit higher zoom levels.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_level: Option<u32>,
+
+    /// Some WMTS layers are displayed as  WMS/WMTS, but for the data export, a different source is used.
+    pub ogc_source: Option<OgcSource>,
 }

--- a/docs/layer-config/layer-source-config.md
+++ b/docs/layer-config/layer-source-config.md
@@ -1,13 +1,15 @@
 # LayerSource Config Type
+
 In the following, all possible structures for the `LayerSource` type are described.
 You can use any of them wherever a `LayerSource` object is required.
 
 ## `CesiumIon` source
+
 The `CesiumIon` source links to a Cesium Ion asset.
+
 ```json5
 {
   type: 'CesiumIon',
-  
   // The id of the asset in Cesium Ion.
   //
   // @type integer
@@ -17,11 +19,12 @@ The `CesiumIon` source links to a Cesium Ion asset.
 ```
 
 ## `Url` source
+
 The `CesiumIon` source links to a fully customizable, static HTTP url.
+
 ```json5
 {
   type: 'Url',
-  
   // The url at which the data can be found.
   //
   // @type string
@@ -31,17 +34,17 @@ The `CesiumIon` source links to a fully customizable, static HTTP url.
 ```
 
 ## `S3` source
+
 The `S3` source links to an S3 object, identified by its bucket and the key within that bucket.
+
 ```json5
 {
   type: 'S3',
-  
   // The name of the bucket.
   //
   // @type string
   // @required
   bucket: 'the-bucket-name',
-
   // The key at which the object is stored.
   //
   // @type string
@@ -51,30 +54,99 @@ The `S3` source links to an S3 object, identified by its bucket and the key with
 ```
 
 ## `Ogc` source
+
 The `Ogc` source links to an OGC API collection.
-> Currently, The `Ogc` source is only supported on S3 tiles.
+> Currently, The `Ogc` source is only supported on 3D tiles.
+
 ```json5
 {
   type: 'Ogc',
-  
-  // The id of the ogc collection.
+  // The OGC source configuration object.
   //
-  // @type integer
+  // @type object
   // @required
-  id: 1,
-
-  // The id of the style with which the data is displayed.
-  //
-  // @type integer | null
-  // @default null
-  style_id: null,
-  
+  ogc_source: {
+    // The type of OGC source.
+    // Possible values: 'gst', 'stac', 'fdsn', 'wms'
+    //
+    // @type string
+    // @required
+    ogcType: 'gst',
+    // For 'gst' type only:
+    // The id of the ogc collection.
+    //
+    // @type integer
+    // @required (for gst)
+    id: 1,
+    // For 'gst' type only:
+    // The id of the style with which the data is displayed.
+    //
+    // @type integer | null
+    // @default null
+    style_id: null,
+    // For 'stac' type only:
+    // The collection identifier.
+    //
+    // @type string
+    // @required (for stac)
+    collection: 'ch.swisstopo.collection_name',
+  },
   // An optional source that will be used instead of Ogc when displaying the layer.
   // When this is set, the OGC API will only be used for layer exports.
   //
   // @type LayerSource | null
   // @default null
   display_source: null,
+}
+```
+
+### OGC Source Types
+
+#### GST (GeoScience Tiles)
+
+Used for accessing 3D tile collections from the GST service.
+
+```json5
+{
+  type: 'Ogc',
+  ogc_source: {
+    ogcType: 'gst',
+    id: 13327,
+    style_id: 5
+    // optional
+  }
+}
+```
+
+#### STAC (SpatioTemporal Asset Catalog)
+
+Used for accessing STAC collections.
+
+```json5
+{
+  type: 'Ogc',
+  ogc_source: {
+    ogcType: 'stac',
+    collection: 'ch.swisstopo.swissbuildings3d_2'
+  },
+  display_source: {
+    type: 'Url',
+    url: 'https://example.com/tileset.json'
+  }
+}
+```
+
+#### FDSN & WMS
+
+Reserved for future use. Not yet implemented.
+
+```json5
+{
+  type: 'Ogc',
+  ogc_source: {
+    ogcType: 'fdsn'
+    // or 'wms'
+  }
 }
 ```
 

--- a/layers/01-maps_and_models/consolidated_rocks.json5
+++ b/layers/01-maps_and_models/consolidated_rocks.json5
@@ -5,7 +5,10 @@
       id: 'top_omm',
       source: {
         type: 'Ogc',
-        id: 10486,
+        ogc_source: {
+          type: 'gst',
+          id: 10486
+        },
         display_source: {
           type: 'CesiumIon',
           asset_id: 3955170

--- a/layers/layers_3dtiles.json5
+++ b/layers/layers_3dtiles.json5
@@ -1,654 +1,731 @@
 {
-    // Shared order of properties
-    order_of_properties: {
-        geomol_consolidated_rocks: [
-            'Name',
-            'Horizon',
-            'HARMOS-ORIGINAL',
-            'Download Move',
-            'Download GoCad',
-            'Download DXF',
-            'Download ASCII',
-            'Download All data'
-        ],
-        geoquat_cs: [
-            'CS-AAT-Cross-section',
-            'CS-AAT-Lithostratigraphy',
-            'CS-AAT-Type',
-            'CS-AAT-Legend',
-            'CS-AAT-Report',
-        ],
-        city_berne: [
-            '3DBern-Unit',
-            '3DBern-Link',
-            '3DBern-Lithology',
-            '3DBern-TectonicUnit',
-            '3DBern-ChronoB-T',
-            '3DBern-OrigDesc',
-            '3DBern-Version',
-            '3DBern-Author',
-            '3DBern-Purpose',
-            '3DBern-Download',
-        ],
-        boreholes_2021: [
-            'bh_pub_XCOORD',
-            'bh_pub_YCOORD',
-            'bh_pub_ZCOORDB',
-            'bh_pub_ORIGNAME',
-            'bh_pub_NAMEPUB',
-            'bh_pub_SHORTNAME',
-            'bh_pub_BOHREDAT',
-            'bh_pub_BOHRTYP',
-            'bh_pub_GRUND',
-            'bh_pub_RESTRICTIO',
-            'bh_pub_TIEFEMD',
-            'bh_pub_DEPTHFROM',
-            'bh_pub_DEPTHTO',
-            'bh_pub_LAYERDESC',
-            'bh_pub_ORIGGEOL',
-            'bh_pub_LITHOLOGY',
-            'bh_pub_LITHOSTRAT',
-            'bh_pub_CHRONOSTR',
-            'bh_pub_TECTO',
-            'bh_pub_USCS1',
-            'bh_pub_USCS2',
-            'bh_pub_USCS3',
-        ]
-    },
-
-    layers: [
-/*
-        // Topic Title
-        // Layer title
-        {
-            type: 'Tiles3d',
-            id: '',
-            source: {
-                type: '',
-                id: ,
-                style_id: ,
-            }
-            order_of_properties: '',
-            download_url: 'https://download.swissgeol.ch/ XXXX',
-            geocat_id: '',
-        },
-*/
-        // Topic Boreholes
-        // Boreholes 2021 - Public
-        {
-            type: 'Tiles3d',
-            id: 'boreholes_public',
-            source: {
-                type: 'CesiumIon',
-                asset_id: 287568,
-            },
-            access: {
-                env: ['local', 'dev'],
-                groups: ['ngm-dev-privileged']
-            },
-            order_of_properties: 'boreholes_2021',
-            download_url: 'https://download.swissgeol.ch/boreholes/bh_open_20210201_00.csv',
-            geocat_id: '3996dfad-69dd-418f-a4e6-5f32b96c760a',
-        },
-        // Boreholes 2021 - Private
-        {
-            type: 'Tiles3d',
-            id: 'boreholes_private',
-            source: {
-                type: 'S3',
-                bucket:'ngm-protected-prod',
-                key: 'tiles/bh_private_20210201_00/tileset.json'
-            },
-            access: {
-                env: ['local', 'dev'],
-                groups: ['ngm-dev-privileged']
-            },
-            order_of_properties: 'boreholes_2021',
-            download_url: '',
-            geocat_id: '',
-        },
-        // 2DSeismik
-        // 2D-Seismik EGEO 001
-        {
-            type: 'Tiles3d',
-            id: 'seismic_2d_21_egeo_001',
-            source: {
-                type: 'Ogc',
-                id: 13327,
-                style_id: 5,
-            }
-        },
-        // 2D-Seismik EGEO 002
-        {
-            type: 'Tiles3d',
-            id: 'seismic_2d_21_egeo_002',
-            source: {
-                type: 'Ogc',
-                id: 13328,
-                style_id: 5,
-            }
-        },
-        // 3D-Seismik
-        // 3D-Seismik - Eclépens 2023
-        {
-            type: 'Tiles3d',
-            id: 'seismic_3d_E11',
-            source: {
-                type: 'Ogc',
-                id: 14279,
-                style_id: 5,
-            },
-            access: {
-                env: ['local', 'dev']
-            }
-        },
-        // Geoenergy
-        {
-            type: 'Tiles3d',
-            id: 'temp_iso_60',
-            source: {
-                type: 'CesiumIon',
-                asset_id: 251755,
-            },
-            geocat_id: '6edca35d-0f08-43b9-9faf-4c7b207888a1'
-        },    
-        {
-            type: 'Tiles3d',
-            id: 'temp_iso_100',
-            source: {
-                type: 'CesiumIon',
-                asset_id: 251787,
-            },
-            geocat_id: '8681fb45-6220-41ef-825a-86210d8a72fc'
-        }, 
-        {
-            type: 'Tiles3d',
-            id: 'temp_iso_150',
-            source: {
-                type: 'CesiumIon',
-                asset_id: 251783,
-            },
-            geocat_id: '31dc428e-a62b-4f6b-a263-e5eca9d9a074'
-        }, 
-        {
-            type: 'Tiles3d',
-            id: 'temp_tomm',
-            source: {
-                type: 'CesiumIon',
-                asset_id: 251747,
-            },
-            geocat_id: '4f9e3f59-891e-434b-bba5-40db1b9495e0'
-        }, 
-        {
-            type: 'Tiles3d',
-            id: 'temp_tuma',
-            source: {
-                type: 'CesiumIon',
-                asset_id: 251782,
-            },
-            geocat_id: '613cdc6f-0237-416d-af16-ae5d2f1934ff'
-        }, 
-        {
-            type: 'Tiles3d',
-            id: 'temp_tums',
-            source: {
-                type: 'CesiumIon',
-                asset_id: 251781,
-            },
-            geocat_id: 'e0be0de5-4ed0-488a-a952-5eb385fd5595'
-        }, 
-        {
-            type: 'Tiles3d',
-            id: 'temp_depth_500',
-            source: {
-                type: 'CesiumIon',
-                asset_id: 251756,
-            },
-            geocat_id: '08e66941-4ebb-4017-8018-b39caa8fd107'
-        }, 
-        {
-            type: 'Tiles3d',
-            id: 'temp_depth_1000',
-            source: {
-                type: 'CesiumIon',
-                asset_id: 251788,
-            },
-            geocat_id: '5e32ea72-a356-4250-b40a-a441165fd936'
-        }, 
-        {
-            type: 'Tiles3d',
-            id: 'temp_depth_1500',
-            source: {
-                type: 'CesiumIon',
-                asset_id: 251790,
-            },
-            geocat_id: '162989d7-5c1c-48fb-8d16-2ccf5be339b9'
-        }, 
-        {
-            type: 'Tiles3d',
-            id: 'temp_depth_2000',
-            source: {
-                type: 'CesiumIon',
-                asset_id: 251786,
-            },
-            geocat_id: 'ac604460-7a7a-44c5-bc5a-41062fbd21ff'
-        }, 
-        {
-            type: 'Tiles3d',
-            id: 'temp_depth_3000',
-            source: {
-                type: 'CesiumIon',
-                asset_id: 251785,
-            },
-            geocat_id: '47f79661-212e-4297-b048-2606db7affa8'
-        }, 
-        {
-            type: 'Tiles3d',
-            id: 'temp_depth_4000',
-            source: {
-                type: 'CesiumIon',
-                asset_id: 251789,
-            },
-            geocat_id: '739e9095-77f6-462d-9a1e-438898cf0c9c'
-        }, 
-
-        // GeoQuat
-        // GeoQuat Cross-sections
-        {
-            type: 'Tiles3d',
-            id: 'geoquat_aaretal_cs',
-            source: {
-                type: 'CesiumIon',
-                asset_id: 472446,
-            },
-            order_of_properties: 'geoquat_cs',
-            geocat_id: 'ab34eb52-30c4-4b69-840b-ef41f47f9e9a'
-        },
-        // Jura 3D
-        // Horizon        
-        {
-            type: 'Tiles3d',
-            id: 'j3d_horizon',
-            source: {
-                type: 'CesiumIon',
-                asset_id: 4171530
-            },
-            //order_of_properties: '',
-            geocat_id: ''
-        },
-        // Faults        
-        {
-            type: 'Tiles3d',
-            id: 'j3d_faults',
-            source: {
-                type: 'CesiumIon',
-                asset_id: 4171517
-            },
-            //order_of_properties: '',
-            geocat_id: ''
-        },
-        // GeoMol      
-        // GeoMol-Cross-sections
-        {
-            type: 'Tiles3d',
-            id: 'geomol_cs',
-            source: {
-                type: 'CesiumIon',
-                asset_id: 452436
-            },
-            download_url: 'https://download.swissgeol.ch/geomol/GeoMol-Cross-Sections.zip',
-            geocat_id: '2cec200c-a47b-4934-8dc1-62c19c39a3dd'
-        },
-        
-        // Horizons
-        // TOMM
-        {
-            type: 'Tiles3d',
-            id: 'top_omm',
-            source: {
-                type: 'Ogc',
-                id: 10486,
-                display_source: {
-                    type: 'CesiumIon',
-                    asset_id: 4180339
-                }
-            },
-            order_of_properties: 'geomol_consolidated_rocks',
-            download_url: 'https://download.swissgeol.ch/geomol/geomol_2021/GeoMol21_Horizons_TOMM_OBJ.zip',
-            geocat_id: 'ea190c99-635c-4cf8-9e17-0bcfa938fbdf',
-        },
-        //TUSM
-        {   
-            type: 'Tiles3d',
-            id: 'top_usm',
-            source: {
-                type: 'Ogc',
-                id: 10487,
-                display_source: {
-                    type: 'CesiumIon',
-                    asset_id: 4182186   
-                }
-            },
-            order_of_properties: 'geomol_consolidated_rocks',
-            download_url: 'https://download.swissgeol.ch/geomol/geomol_2021/GeoMol21_Horizons_TUSM_OBJ.zip',
-            geocat_id: '2d7a0729-dd29-40fa-ad4f-b09f94b7fb00',
-        },
-        // TUMM
-        {
-            type: 'Tiles3d',
-            id: 'top_umm',
-            source: {
-                type: 'Ogc',
-                id: 10485,
-                display_source: {
-                    type: 'CesiumIon',
-                    asset_id: 4182207
-                }
-            },
-            order_of_properties: 'geomol_consolidated_rocks',
-            download_url: 'https://download.swissgeol.ch/geomol/geomol_2021/GeoMol21_Horizons_TUMM_OBJ.zip',
-            geocat_id: 'fedb8d24-a000-4b78-9e6e-fb90305ad3ea',
-        },
-        // BCen
-        {
-            type: 'Tiles3d',
-            id: 'base_cen',
-            source: {
-                type: 'Ogc',
-                id: 10489,
-                display_source: {
-                    type: 'CesiumIon',
-                    asset_id: 4182277
-                }
-            },
-            order_of_properties: 'geomol_consolidated_rocks',
-            download_url: 'https://download.swissgeol.ch/geomol/geomol_2021/GeoMol21_Horizons_BCen_OBJ.zip',
-            geocat_id: '0e780e6c-18e2-4014-ad16-b35124706580',
-        },
-        // TCret
-        {
-            type: 'Tiles3d',
-            id: 'top_cret',
-            source: {
-                type: 'Ogc',
-                id: 10488,
-                display_source: {
-                    type: 'CesiumIon',
-                    asset_id: 4182209
-                }
-            },
-            order_of_properties: 'geomol_consolidated_rocks',
-            download_url: 'https://download.swissgeol.ch/geomol/geomol_2021/GeoMol21_Horizons_TCret_OBJ.zip',
-            geocat_id: '09334747-14e7-40d6-881b-00e552b71f61',
-        },
-        // TUMa
-        {
-            type: 'Tiles3d',
-            id: 'top_uma',
-            source: {
-                type: 'Ogc',
-                id: 10468,
-                display_source: {
-                    type: 'CesiumIon',
-                    asset_id: 4182292
-                }
-            },
-            order_of_properties: 'geomol_consolidated_rocks',
-            download_url: 'https://download.swissgeol.ch/geomol/geomol_2021/GeoMol21_Horizons_TUMa_OBJ.zip',
-            geocat_id: '2378cab1-4673-4837-b12e-a35aefab389a',
-        },
-        // TLMa
-        {
-            type: 'Tiles3d',
-            id: 'top_lma',
-            source: {
-                type: 'Ogc',
-                id: 10490,
-                display_source: {
-                    type: 'CesiumIon',
-                    asset_id: 4182306
-                }
-            },
-            order_of_properties: 'geomol_consolidated_rocks',
-            download_url: 'https://download.swissgeol.ch/geomol/geomol_2021/GeoMol21_Horizons_TLMa_OBJ.zip',
-            geocat_id: 'af51f4eb-1430-4e4e-a679-3c0eefb4a6b3',
-        },
-        // TDo
-        {
-            type: 'Tiles3d',
-            id: 'top_do',
-            source: {
-                type: 'Ogc',
-                id: 10491,
-                display_source: {
-                    type: 'CesiumIon',
-                    asset_id: 4182314
-                }
-            },
-            order_of_properties: 'geomol_consolidated_rocks',
-            download_url: 'https://download.swissgeol.ch/geomol/geomol_2021/GeoMol21_Horizons_TDo_OBJ.zip',
-            geocat_id: '0dea083d-23b0-4c5b-b82d-1cd7bda3d583',
-        },
-        // TLi
-        {
-            type: 'Tiles3d',
-            id: 'top_li',
-            source: {
-                type: 'Ogc',
-                id: 10492,
-                display_source: {
-                    type: 'CesiumIon',
-                    asset_id: 4182351
-                }
-            },
-            order_of_properties: 'geomol_consolidated_rocks',
-            download_url: 'https://download.swissgeol.ch/geomol/geomol_2021/GeoMol21_Horizons_TLi_OBJ.zip',
-            geocat_id: '793a40d6-ab83-4e1e-80d7-d7c49bf00f3c'
-        },
-        // TKeu
-        {
-            type: 'Tiles3d',
-            id: 'top_keu',
-            source: {
-                type: 'Ogc',
-                id: 10497,
-                display_source: {
-                    type: 'CesiumIon',
-                    asset_id: 4182626
-                }
-            },
-            order_of_properties: 'geomol_consolidated_rocks',
-            download_url: 'https://download.swissgeol.ch/geomol/geomol_2021/GeoMol21_Horizons_TKeu_OBJ.zip',
-            geocat_id: 'e2344c21-2139-4494-8679-36fe30d034f9'
-        },
-        //TMus
-        {
-            type: 'Tiles3d',
-            id: 'top_mus',
-            source: {
-                type: 'Ogc',
-                id: 10498,
-                display_source: {
-                    type: 'CesiumIon',
-                    asset_id: 4182378
-                }
-            },
-            order_of_properties: 'geomol_consolidated_rocks',
-            download_url: 'https://download.swissgeol.ch/geomol/geomol_2021/GeoMol21_Horizons_TMus_OBJ.zip',
-            geocat_id: 'dae3dd91-a04c-46c5-aa49-de6235c0478a',
-        },
-        //BMes
-        {
-            type: 'Tiles3d',
-            id: 'base_mes',
-            source: {
-                type: 'Ogc',
-                id: 10496,
-                display_source: {
-                    type: 'CesiumIon',
-                    asset_id: 4182395
-                }
-            },
-            order_of_properties: 'geomol_consolidated_rocks',
-            download_url: 'https://download.swissgeol.ch/geomol/geomol_2021/GeoMol21_Horizons_BMes_OBJ.zip',
-            geocat_id: 'ec67a58d-531e-4dae-98da-85c49525b4d2',
-        },
-        //TCarb
-        {
-            type: 'Tiles3d',
-            id: 'top_carb',
-            source: {
-                type: 'Ogc',
-                id: 10493,
-                display_source: {
-                    type: 'CesiumIon',
-                    asset_id: 4182413
-                }
-            },
-            order_of_properties: 'geomol_consolidated_rocks',
-            download_url: 'https://download.swissgeol.ch/geomol/geomol_2021/GeoMol21_Horizons_TCarb_OBJ.zip',
-            geocat_id: 'faa96a07-1877-4fa6-b2aa-536761d7c012',
-        },
-        //BPC
-        {
-            type: 'Tiles3d',
-            id: 'base_pc',
-            source: {
-                type: 'Ogc',
-                id: 10494,
-                display_source: {
-                    type: 'CesiumIon',
-                    asset_id: 4182446
-                }
-            },
-            order_of_properties: 'geomol_consolidated_rocks',
-            download_url: 'https://download.swissgeol.ch/geomol/geomol_2021/GeoMol21_Horizons_BPC_OBJ.zip',
-            geocat_id: 'faa96a07-1877-4fa6-b2aa-536761d7c012',
-        },
-        //BPC
-        {
-            type: 'Tiles3d',
-            id: 'base_pc_vermutet',
-            source: {
-                type: 'Ogc',
-                id: 10495,
-                display_source: {
-                    type: 'CesiumIon',
-                    asset_id: 4182486
-                }
-            },
-            order_of_properties: 'geomol_consolidated_rocks',
-            download_url: 'https://download.swissgeol.ch/geomol/geomol_2021/GeoMol21_Horizons_BPC_vermutet_OBJ.zip',
-            geocat_id: '0f1acc23-bdfc-40bf-94b7-7be10f0f78ed',
-        },
-        // Faults
-        {
-            type: 'Tiles3d',
-            id: 'geomol_faults',
-            source: {
-                type: 'CesiumIon',
-                asset_id: 267872
-            },
-            download_url: 'https://download.swissgeol.ch/geomol/GeoMol-Faults.zip',
-            geocat_id: 'f5661c1b-49e5-41e9-baf1-dee4811eb907',
-        },
-        // SA3D
-        // SA3D - Aaremassive - Horizons
-        {
-            type: 'Tiles3d',
-            id: 'sa3d_aaremassive_horizons',
-            source: {
-                type: 'CesiumIon',
-                asset_id: 4130307
-            },
-            access: {
-                env: ['local', 'dev'],
-                // groups: ['ngm-dev-privileged']
-            },
-            //download_url: 'https://download.swissgeol.ch/geomol/GeoMol-Faults.zip',
-            //geocat_id: 'f5661c1b-49e5-41e9-baf1-dee4811eb907',
-        },
-        // SA3D - Aaremassive - Structures
-        {
-            type: 'Tiles3d',
-            id: 'sa3d_aaremassive_structures',
-            source: {
-                type: 'CesiumIon',
-                asset_id: 4130256
-            },
-            access: {
-                env: ['local', 'dev'],
-                // groups: ['ngm-dev-privileged']
-            },
-            //download_url: 'https://download.swissgeol.ch/geomol/GeoMol-Faults.zip',
-            //geocat_id: 'f5661c1b-49e5-41e9-baf1-dee4811eb907',
-        },
-        // SA3D - Aaremassive - Cross sections
-        {
-            type: 'Tiles3d',
-            id: 'sa3d_aaremassive_cs',
-            source: {
-                type: 'CesiumIon',
-                asset_id: 4130065
-            },
-            access: {
-                env: ['local', 'dev'],
-                // groups: ['ngm-dev-privileged']
-            },
-            //download_url: 'https://download.swissgeol.ch/geomol/GeoMol-Faults.zip',
-            //geocat_id: 'f5661c1b-49e5-41e9-baf1-dee4811eb907',
-        },
-        // City of Berne
-        {
-            type: 'Tiles3d',
-            id: 'local_model_city_berne',
-            source: {
-                type: 'CesiumIon',
-                asset_id: 493224,
-            },
-            order_of_properties: 'city_berne',
-            geocat_id: '372c25ac-fb8a-44ee-8f81-6427939f6353',
-        },
-        // Tunnel
-        {
-            type: 'Tiles3d',
-            id: 'tunnel_road',
-            source: {
-                type: 'CesiumIon',
-                asset_id: 244982
-            },
-            geocat_id: '752146b4-7fd4-4621-8cf8-fdb19f5335a5',
-        },
-        {
-            type: 'Tiles3d',
-            id: 'tunnel_railway',
-            source: {
-                type: 'CesiumIon',
-                asset_id: 244984,
-            },
-            geocat_id: '4897848c-3777-4636-9c7e-16ef91c723f6',
-        },
-        {
-            type: 'Tiles3d',
-            id: 'tunnel_water',
-            source: {
-                type: 'CesiumIon',
-                asset_id: 244985,
-            },
-            geocat_id: '71ee97cb-91f8-427d-b217-f293a0a9760a',
-        },
-
-        // swissBuildings
-        {
-            type: 'Tiles3d',
-            id: 'swiss_buildings',
-            source: {
-                type: 'Url',
-                url:'https://vectortiles0.geo.admin.ch/3d-tiles/ch.swisstopo.swisstlm3d.3d/20201020/tileset.json',
-            },
-            geocat_id: '21c98c73-48da-408b-ab73-8f1ab9d5fbe4',
-        },
-
-            
+  // Shared order of properties
+  order_of_properties: {
+    geomol_consolidated_rocks: [
+      'Name',
+      'Horizon',
+      'HARMOS-ORIGINAL',
+      'Download Move',
+      'Download GoCad',
+      'Download DXF',
+      'Download ASCII',
+      'Download All data'
+    ],
+    geoquat_cs: [
+      'CS-AAT-Cross-section',
+      'CS-AAT-Lithostratigraphy',
+      'CS-AAT-Type',
+      'CS-AAT-Legend',
+      'CS-AAT-Report',
+    ],
+    city_berne: [
+      '3DBern-Unit',
+      '3DBern-Link',
+      '3DBern-Lithology',
+      '3DBern-TectonicUnit',
+      '3DBern-ChronoB-T',
+      '3DBern-OrigDesc',
+      '3DBern-Version',
+      '3DBern-Author',
+      '3DBern-Purpose',
+      '3DBern-Download',
+    ],
+    boreholes_2021: [
+      'bh_pub_XCOORD',
+      'bh_pub_YCOORD',
+      'bh_pub_ZCOORDB',
+      'bh_pub_ORIGNAME',
+      'bh_pub_NAMEPUB',
+      'bh_pub_SHORTNAME',
+      'bh_pub_BOHREDAT',
+      'bh_pub_BOHRTYP',
+      'bh_pub_GRUND',
+      'bh_pub_RESTRICTIO',
+      'bh_pub_TIEFEMD',
+      'bh_pub_DEPTHFROM',
+      'bh_pub_DEPTHTO',
+      'bh_pub_LAYERDESC',
+      'bh_pub_ORIGGEOL',
+      'bh_pub_LITHOLOGY',
+      'bh_pub_LITHOSTRAT',
+      'bh_pub_CHRONOSTR',
+      'bh_pub_TECTO',
+      'bh_pub_USCS1',
+      'bh_pub_USCS2',
+      'bh_pub_USCS3',
     ]
+  },
+  layers: [
+    /*
+            // Topic Title
+            // Layer title
+            {
+                type: 'Tiles3d',
+                id: '',
+                source: {
+                    type: '',
+                    id: ,
+                    style_id: ,
+                }
+                order_of_properties: '',
+                download_url: 'https://download.swissgeol.ch/ XXXX',
+                geocat_id: '',
+            },
+    */
+    // Topic Boreholes
+    // Boreholes 2021 - Public
+    {
+      type: 'Tiles3d',
+      id: 'boreholes_public',
+      source: {
+        type: 'CesiumIon',
+        asset_id: 287568,
+      },
+      access: {
+        env: [
+          'local',
+          'dev'
+        ],
+        groups: [
+          'ngm-dev-privileged'
+        ]
+      },
+      order_of_properties: 'boreholes_2021',
+      download_url: 'https://download.swissgeol.ch/boreholes/bh_open_20210201_00.csv',
+      geocat_id: '3996dfad-69dd-418f-a4e6-5f32b96c760a',
+    },
+    // Boreholes 2021 - Private
+    {
+      type: 'Tiles3d',
+      id: 'boreholes_private',
+      source: {
+        type: 'S3',
+        bucket: 'ngm-protected-prod',
+        key: 'tiles/bh_private_20210201_00/tileset.json'
+      },
+      access: {
+        env: [
+          'local',
+          'dev'
+        ],
+        groups: [
+          'ngm-dev-privileged'
+        ]
+      },
+      order_of_properties: 'boreholes_2021',
+      download_url: '',
+      geocat_id: '',
+    },
+    // 2DSeismik
+    // 2D-Seismik EGEO 001
+    {
+      type: 'Tiles3d',
+      id: 'seismic_2d_21_egeo_001',
+      source: {
+        type: 'Ogc',
+        ogc_source: {
+          type: 'gst',
+          id: 13327,
+          style_id: 5,
+        }
+      }
+    },
+    // 2D-Seismik EGEO 002
+    {
+      type: 'Tiles3d',
+      id: 'seismic_2d_21_egeo_002',
+      source: {
+        type: 'Ogc',
+        ogc_source: {
+          type: 'gst',
+          id: 13328,
+          style_id: 5,
+        }
+      }
+    },
+    // 3D-Seismik
+    // 3D-Seismik - Eclépens 2023
+    {
+      type: 'Tiles3d',
+      id: 'seismic_3d_E11',
+      source: {
+        type: 'Ogc',
+        ogc_source: {
+          type: 'gst',
+          id: 14279,
+          style_id: 5,
+        }
+      },
+      access: {
+        env: [
+          'local',
+          'dev'
+        ]
+      }
+    },
+    // Geoenergy
+    {
+      type: 'Tiles3d',
+      id: 'temp_iso_60',
+      source: {
+        type: 'CesiumIon',
+        asset_id: 251755,
+      },
+      geocat_id: '6edca35d-0f08-43b9-9faf-4c7b207888a1'
+    },
+    {
+      type: 'Tiles3d',
+      id: 'temp_iso_100',
+      source: {
+        type: 'CesiumIon',
+        asset_id: 251787,
+      },
+      geocat_id: '8681fb45-6220-41ef-825a-86210d8a72fc'
+    },
+    {
+      type: 'Tiles3d',
+      id: 'temp_iso_150',
+      source: {
+        type: 'CesiumIon',
+        asset_id: 251783,
+      },
+      geocat_id: '31dc428e-a62b-4f6b-a263-e5eca9d9a074'
+    },
+    {
+      type: 'Tiles3d',
+      id: 'temp_tomm',
+      source: {
+        type: 'CesiumIon',
+        asset_id: 251747,
+      },
+      geocat_id: '4f9e3f59-891e-434b-bba5-40db1b9495e0'
+    },
+    {
+      type: 'Tiles3d',
+      id: 'temp_tuma',
+      source: {
+        type: 'CesiumIon',
+        asset_id: 251782,
+      },
+      geocat_id: '613cdc6f-0237-416d-af16-ae5d2f1934ff'
+    },
+    {
+      type: 'Tiles3d',
+      id: 'temp_tums',
+      source: {
+        type: 'CesiumIon',
+        asset_id: 251781,
+      },
+      geocat_id: 'e0be0de5-4ed0-488a-a952-5eb385fd5595'
+    },
+    {
+      type: 'Tiles3d',
+      id: 'temp_depth_500',
+      source: {
+        type: 'CesiumIon',
+        asset_id: 251756,
+      },
+      geocat_id: '08e66941-4ebb-4017-8018-b39caa8fd107'
+    },
+    {
+      type: 'Tiles3d',
+      id: 'temp_depth_1000',
+      source: {
+        type: 'CesiumIon',
+        asset_id: 251788,
+      },
+      geocat_id: '5e32ea72-a356-4250-b40a-a441165fd936'
+    },
+    {
+      type: 'Tiles3d',
+      id: 'temp_depth_1500',
+      source: {
+        type: 'CesiumIon',
+        asset_id: 251790,
+      },
+      geocat_id: '162989d7-5c1c-48fb-8d16-2ccf5be339b9'
+    },
+    {
+      type: 'Tiles3d',
+      id: 'temp_depth_2000',
+      source: {
+        type: 'CesiumIon',
+        asset_id: 251786,
+      },
+      geocat_id: 'ac604460-7a7a-44c5-bc5a-41062fbd21ff'
+    },
+    {
+      type: 'Tiles3d',
+      id: 'temp_depth_3000',
+      source: {
+        type: 'CesiumIon',
+        asset_id: 251785,
+      },
+      geocat_id: '47f79661-212e-4297-b048-2606db7affa8'
+    },
+    {
+      type: 'Tiles3d',
+      id: 'temp_depth_4000',
+      source: {
+        type: 'CesiumIon',
+        asset_id: 251789,
+      },
+      geocat_id: '739e9095-77f6-462d-9a1e-438898cf0c9c'
+    },
+    // GeoQuat
+    // GeoQuat Cross-sections
+    {
+      type: 'Tiles3d',
+      id: 'geoquat_aaretal_cs',
+      source: {
+        type: 'CesiumIon',
+        asset_id: 472446,
+      },
+      order_of_properties: 'geoquat_cs',
+      geocat_id: 'ab34eb52-30c4-4b69-840b-ef41f47f9e9a'
+    },
+    // Jura 3D
+    // Horizon
+    {
+      type: 'Tiles3d',
+      id: 'j3d_horizon',
+      source: {
+        type: 'CesiumIon',
+        asset_id: 4171530
+      },
+      //order_of_properties: '',
+      geocat_id: ''
+    },
+    // Faults
+    {
+      type: 'Tiles3d',
+      id: 'j3d_faults',
+      source: {
+        type: 'CesiumIon',
+        asset_id: 4171517
+      },
+      //order_of_properties: '',
+      geocat_id: ''
+    },
+    // GeoMol
+    // GeoMol-Cross-sections
+    {
+      type: 'Tiles3d',
+      id: 'geomol_cs',
+      source: {
+        type: 'CesiumIon',
+        asset_id: 452436
+      },
+      download_url: 'https://download.swissgeol.ch/geomol/GeoMol-Cross-Sections.zip',
+      geocat_id: '2cec200c-a47b-4934-8dc1-62c19c39a3dd'
+    },
+    // Horizons
+    // TOMM
+    {
+      type: 'Tiles3d',
+      id: 'top_omm',
+      source: {
+        type: 'Ogc',
+        ogc_source: {
+          type: 'gst',
+          id: 10486,
+        },
+        display_source: {
+          type: 'CesiumIon',
+          asset_id: 4180339
+        }
+      },
+      order_of_properties: 'geomol_consolidated_rocks',
+      download_url: 'https://download.swissgeol.ch/geomol/geomol_2021/GeoMol21_Horizons_TOMM_OBJ.zip',
+      geocat_id: 'ea190c99-635c-4cf8-9e17-0bcfa938fbdf',
+    },
+    //TUSM
+    {
+      type: 'Tiles3d',
+      id: 'top_usm',
+      source: {
+        type: 'Ogc',
+        ogc_source: {
+          type: 'gst',
+          id: 10487,
+        },
+        display_source: {
+          type: 'CesiumIon',
+          asset_id: 4182186
+        }
+      },
+      order_of_properties: 'geomol_consolidated_rocks',
+      download_url: 'https://download.swissgeol.ch/geomol/geomol_2021/GeoMol21_Horizons_TUSM_OBJ.zip',
+      geocat_id: '2d7a0729-dd29-40fa-ad4f-b09f94b7fb00',
+    },
+    // TUMM
+    {
+      type: 'Tiles3d',
+      id: 'top_umm',
+      source: {
+        type: 'Ogc',
+        ogc_source: {
+          type: 'gst',
+          id: 10485,
+        },
+        display_source: {
+          type: 'CesiumIon',
+          asset_id: 4182207
+        }
+      },
+      order_of_properties: 'geomol_consolidated_rocks',
+      download_url: 'https://download.swissgeol.ch/geomol/geomol_2021/GeoMol21_Horizons_TUMM_OBJ.zip',
+      geocat_id: 'fedb8d24-a000-4b78-9e6e-fb90305ad3ea',
+    },
+    // BCen
+    {
+      type: 'Tiles3d',
+      id: 'base_cen',
+      source: {
+        type: 'Ogc',
+        ogc_source: {
+          type: 'gst',
+          id: 10489,
+        },
+        display_source: {
+          type: 'CesiumIon',
+          asset_id: 4182277
+        }
+      },
+      order_of_properties: 'geomol_consolidated_rocks',
+      download_url: 'https://download.swissgeol.ch/geomol/geomol_2021/GeoMol21_Horizons_BCen_OBJ.zip',
+      geocat_id: '0e780e6c-18e2-4014-ad16-b35124706580',
+    },
+    // TCret
+    {
+      type: 'Tiles3d',
+      id: 'top_cret',
+      source: {
+        type: 'Ogc',
+        ogc_source: {
+          type: 'gst',
+          id: 10488,
+        },
+        display_source: {
+          type: 'CesiumIon',
+          asset_id: 4182209
+        }
+      },
+      order_of_properties: 'geomol_consolidated_rocks',
+      download_url: 'https://download.swissgeol.ch/geomol/geomol_2021/GeoMol21_Horizons_TCret_OBJ.zip',
+      geocat_id: '09334747-14e7-40d6-881b-00e552b71f61',
+    },
+    // TUMa
+    {
+      type: 'Tiles3d',
+      id: 'top_uma',
+      source: {
+        type: 'Ogc',
+        ogc_source: {
+          type: 'gst',
+          id: 10468,
+        },
+        display_source: {
+          type: 'CesiumIon',
+          asset_id: 4182292
+        }
+      },
+      order_of_properties: 'geomol_consolidated_rocks',
+      download_url: 'https://download.swissgeol.ch/geomol/geomol_2021/GeoMol21_Horizons_TUMa_OBJ.zip',
+      geocat_id: '2378cab1-4673-4837-b12e-a35aefab389a',
+    },
+    // TLMa
+    {
+      type: 'Tiles3d',
+      id: 'top_lma',
+      source: {
+        type: 'Ogc',
+        ogc_source: {
+          type: 'gst',
+          id: 10490,
+        },
+        display_source: {
+          type: 'CesiumIon',
+          asset_id: 4182306
+        }
+      },
+      order_of_properties: 'geomol_consolidated_rocks',
+      download_url: 'https://download.swissgeol.ch/geomol/geomol_2021/GeoMol21_Horizons_TLMa_OBJ.zip',
+      geocat_id: 'af51f4eb-1430-4e4e-a679-3c0eefb4a6b3',
+    },
+    // TDo
+    {
+      type: 'Tiles3d',
+      id: 'top_do',
+      source: {
+        type: 'Ogc',
+        ogc_source: {
+          type: 'gst',
+          id: 10491,
+        },
+        display_source: {
+          type: 'CesiumIon',
+          asset_id: 4182314
+        }
+      },
+      order_of_properties: 'geomol_consolidated_rocks',
+      download_url: 'https://download.swissgeol.ch/geomol/geomol_2021/GeoMol21_Horizons_TDo_OBJ.zip',
+      geocat_id: '0dea083d-23b0-4c5b-b82d-1cd7bda3d583',
+    },
+    // TLi
+    {
+      type: 'Tiles3d',
+      id: 'top_li',
+      source: {
+        type: 'Ogc',
+        ogc_source: {
+          type: 'gst',
+          id: 10492,
+        },
+        display_source: {
+          type: 'CesiumIon',
+          asset_id: 4182351
+        }
+      },
+      order_of_properties: 'geomol_consolidated_rocks',
+      download_url: 'https://download.swissgeol.ch/geomol/geomol_2021/GeoMol21_Horizons_TLi_OBJ.zip',
+      geocat_id: '793a40d6-ab83-4e1e-80d7-d7c49bf00f3c'
+    },
+    // TKeu
+    {
+      type: 'Tiles3d',
+      id: 'top_keu',
+      source: {
+        type: 'Ogc',
+        ogc_source: {
+          type: 'gst',
+          id: 10497,
+        },
+        display_source: {
+          type: 'CesiumIon',
+          asset_id: 4182626
+        }
+      },
+      order_of_properties: 'geomol_consolidated_rocks',
+      download_url: 'https://download.swissgeol.ch/geomol/geomol_2021/GeoMol21_Horizons_TKeu_OBJ.zip',
+      geocat_id: 'e2344c21-2139-4494-8679-36fe30d034f9'
+    },
+    //TMus
+    {
+      type: 'Tiles3d',
+      id: 'top_mus',
+      source: {
+        type: 'Ogc',
+        ogc_source: {
+          type: 'gst',
+          id: 10498,
+        },
+        display_source: {
+          type: 'CesiumIon',
+          asset_id: 4182378
+        }
+      },
+      order_of_properties: 'geomol_consolidated_rocks',
+      download_url: 'https://download.swissgeol.ch/geomol/geomol_2021/GeoMol21_Horizons_TMus_OBJ.zip',
+      geocat_id: 'dae3dd91-a04c-46c5-aa49-de6235c0478a',
+    },
+    //BMes
+    {
+      type: 'Tiles3d',
+      id: 'base_mes',
+      source: {
+        type: 'Ogc',
+        ogc_source: {
+          type: 'gst',
+          id: 10496,
+        },
+        display_source: {
+          type: 'CesiumIon',
+          asset_id: 4182395
+        }
+      },
+      order_of_properties: 'geomol_consolidated_rocks',
+      download_url: 'https://download.swissgeol.ch/geomol/geomol_2021/GeoMol21_Horizons_BMes_OBJ.zip',
+      geocat_id: 'ec67a58d-531e-4dae-98da-85c49525b4d2',
+    },
+    //TCarb
+    {
+      type: 'Tiles3d',
+      id: 'top_carb',
+      source: {
+        type: 'Ogc',
+        ogc_source: {
+          type: 'gst',
+          id: 10493,
+        },
+        display_source: {
+          type: 'CesiumIon',
+          asset_id: 4182413
+        }
+      },
+      order_of_properties: 'geomol_consolidated_rocks',
+      download_url: 'https://download.swissgeol.ch/geomol/geomol_2021/GeoMol21_Horizons_TCarb_OBJ.zip',
+      geocat_id: 'faa96a07-1877-4fa6-b2aa-536761d7c012',
+    },
+    //BPC
+    {
+      type: 'Tiles3d',
+      id: 'base_pc',
+      source: {
+        type: 'Ogc',
+        ogc_source: {
+          type: 'gst',
+          id: 10494,
+        },
+        display_source: {
+          type: 'CesiumIon',
+          asset_id: 4182446
+        }
+      },
+      order_of_properties: 'geomol_consolidated_rocks',
+      download_url: 'https://download.swissgeol.ch/geomol/geomol_2021/GeoMol21_Horizons_BPC_OBJ.zip',
+      geocat_id: 'faa96a07-1877-4fa6-b2aa-536761d7c012',
+    },
+    //BPC
+    {
+      type: 'Tiles3d',
+      id: 'base_pc_vermutet',
+      source: {
+        type: 'Ogc',
+        ogc_source: {
+          type: 'gst',
+          id: 10495,
+        },
+        display_source: {
+          type: 'CesiumIon',
+          asset_id: 4182486
+        }
+      },
+      order_of_properties: 'geomol_consolidated_rocks',
+      download_url: 'https://download.swissgeol.ch/geomol/geomol_2021/GeoMol21_Horizons_BPC_vermutet_OBJ.zip',
+      geocat_id: '0f1acc23-bdfc-40bf-94b7-7be10f0f78ed',
+    },
+    // Faults
+    {
+      type: 'Tiles3d',
+      id: 'geomol_faults',
+      source: {
+        type: 'CesiumIon',
+        asset_id: 267872
+      },
+      download_url: 'https://download.swissgeol.ch/geomol/GeoMol-Faults.zip',
+      geocat_id: 'f5661c1b-49e5-41e9-baf1-dee4811eb907',
+    },
+    // SA3D
+    // SA3D - Aaremassive - Horizons
+    {
+      type: 'Tiles3d',
+      id: 'sa3d_aaremassive_horizons',
+      source: {
+        type: 'CesiumIon',
+        asset_id: 4130307
+      },
+      access: {
+        env: [
+          'local',
+          'dev'
+        ],
+        // groups: ['ngm-dev-privileged']
+      },
+      //download_url: 'https://download.swissgeol.ch/geomol/GeoMol-Faults.zip',
+      //geocat_id: 'f5661c1b-49e5-41e9-baf1-dee4811eb907',
+    },
+    // SA3D - Aaremassive - Structures
+    {
+      type: 'Tiles3d',
+      id: 'sa3d_aaremassive_structures',
+      source: {
+        type: 'CesiumIon',
+        asset_id: 4130256
+      },
+      access: {
+        env: [
+          'local',
+          'dev'
+        ],
+        // groups: ['ngm-dev-privileged']
+      },
+      //download_url: 'https://download.swissgeol.ch/geomol/GeoMol-Faults.zip',
+      //geocat_id: 'f5661c1b-49e5-41e9-baf1-dee4811eb907',
+    },
+    // SA3D - Aaremassive - Cross sections
+    {
+      type: 'Tiles3d',
+      id: 'sa3d_aaremassive_cs',
+      source: {
+        type: 'CesiumIon',
+        asset_id: 4130065
+      },
+      access: {
+        env: [
+          'local',
+          'dev'
+        ],
+        // groups: ['ngm-dev-privileged']
+      },
+      //download_url: 'https://download.swissgeol.ch/geomol/GeoMol-Faults.zip',
+      //geocat_id: 'f5661c1b-49e5-41e9-baf1-dee4811eb907',
+    },
+    // City of Berne
+    {
+      type: 'Tiles3d',
+      id: 'local_model_city_berne',
+      source: {
+        type: 'CesiumIon',
+        asset_id: 493224,
+      },
+      order_of_properties: 'city_berne',
+      geocat_id: '372c25ac-fb8a-44ee-8f81-6427939f6353',
+    },
+    // Tunnel
+    {
+      type: 'Tiles3d',
+      id: 'tunnel_road',
+      source: {
+        type: 'CesiumIon',
+        asset_id: 244982
+      },
+      geocat_id: '752146b4-7fd4-4621-8cf8-fdb19f5335a5',
+    },
+    {
+      type: 'Tiles3d',
+      id: 'tunnel_railway',
+      source: {
+        type: 'CesiumIon',
+        asset_id: 244984,
+      },
+      geocat_id: '4897848c-3777-4636-9c7e-16ef91c723f6',
+    },
+    {
+      type: 'Tiles3d',
+      id: 'tunnel_water',
+      source: {
+        type: 'CesiumIon',
+        asset_id: 244985,
+      },
+      geocat_id: '71ee97cb-91f8-427d-b217-f293a0a9760a',
+    },
+    // swissBuildings
+    {
+      type: 'Tiles3d',
+      id: 'swiss_buildings',
+      source: {
+        type: 'Ogc',
+        ogc_source: {
+          type: 'stac',
+          collection: 'ch.swisstopo.swissbuildings3d_2',
+        },
+        display_source: {
+          type: 'Url',
+          url: 'https://vectortiles0.geo.admin.ch/3d-tiles/ch.swisstopo.swisstlm3d.3d/20201020/tileset.json'
+        }
+      },
+      geocat_id: '21c98c73-48da-408b-ab73-8f1ab9d5fbe4',
+    },
+  ]
 }

--- a/layers/layers_wmts.json5
+++ b/layers/layers_wmts.json5
@@ -7,7 +7,11 @@
       max_level: 18,
       opacity: 0.7,
       geocat_id: '2467ab13-e794-4c13-8c55-59fe276398c5',
-      legend: true
+      legend: true,
+      ogc_source: {
+        type: 'stac',
+        collection: 'ch.swisstopo.geologie-geocover',
+      }
     },
     {
       type: 'Wmts',

--- a/layers/layers_wmts.json5
+++ b/layers/layers_wmts.json5
@@ -782,6 +782,10 @@
       opacity: 0.7,
       geocat_id: '376f86bd-c46c-4b89-8f36-717641706226',
       legend: true,
+      ogc_source: {
+        type: 'stac',
+        collection: 'ch.swisstopo.swissalti3d',
+      }
     },
     {
       type: 'Wmts',
@@ -790,6 +794,10 @@
       opacity: 0.7,
       geocat_id: '1964cc81-5298-460f-9228-41120315bea8',
       legend: true,
+      ogc_source: {
+        type: 'stac',
+        collection: 'ch.swisstopo.swissalti3d',
+      }
     },
     {
       type: 'Wmts',

--- a/layers/special/swissBEDROCK.json5
+++ b/layers/special/swissBEDROCK.json5
@@ -4,9 +4,16 @@
       // Layer Top Bedrock Geotiff
       type: 'Tiff',
       id: 'ch.swisstopo.swissbedrock-geotiff',
-      source:  {
-        type: 'Url',
-        url: 'https://download.swissgeol.ch/swissbedrock/release_01/swissBEDROCK_R1.tif',
+      source: {
+        type: 'Ogc',
+        ogc_source: {
+          type: 'stac',
+          collection: 'ch.swisstopo.geologie-swissbedrock',
+        },
+        display_source: {
+          type: 'Url',
+          url: 'https://download.swissgeol.ch/swissbedrock/release_01/swissBEDROCK_R1.tif'
+        },
       },
       opacity: 0.5,
       download_url: {
@@ -40,7 +47,10 @@
           index: 4,
           name: 'Version',
           display: {
-            bounds: [221104, 250519],
+            bounds: [
+              221104,
+              250519
+            ],
             color_map: 'swissBEDROCK_Version',
             is_discrete: true,
           },
@@ -55,7 +65,10 @@
           name: 'Change',
           unit: 'Meters',
           display: {
-            bounds: [-30, 30],
+            bounds: [
+              -30,
+              30
+            ],
             color_map: 'swissBEDROCK_Change'
           },
         },
@@ -88,12 +101,11 @@
         }
       ],
     },
-
     {
       // Layer Top Bedrock Geotiff with Terrain
       type: 'Tiff',
       id: 'ch.swisstopo.swissbedrock-geotiff-with-terrain',
-      source:  {
+      source: {
         type: 'Url',
         url: 'https://download.swissgeol.ch/swissbedrock/release_01/swissBEDROCK_R1.tif',
       },
@@ -133,7 +145,10 @@
           index: 4,
           name: 'Version',
           display: {
-            bounds: [221104, 250519],
+            bounds: [
+              221104,
+              250519
+            ],
             color_map: 'swissBEDROCK_Version',
             is_discrete: true,
           },
@@ -148,7 +163,10 @@
           name: 'Change',
           unit: 'Meters',
           display: {
-            bounds: [-30, 30],
+            bounds: [
+              -30,
+              30
+            ],
             color_map: 'swissBEDROCK_Change'
           },
         },
@@ -184,31 +202,63 @@
   ],
   'tiff_displays': {
     TMUD: {
-      bounds: [-1, 800],
+      bounds: [
+        -1,
+        800
+      ],
       no_data: 0,
       color_map: 'swissBEDROCK_TMUD',
-      steps: [3, 10, 50, 100, 200, 800],
+      steps: [
+        3,
+        10,
+        50,
+        100,
+        200,
+        800
+      ],
     },
     BEM: {
-      bounds: [4535, -433],
+      bounds: [
+        4535,
+        -433
+      ],
       color_map: 'swissBEDROCK_BEM',
       steps: [
-        { value: -400, label: '<-400' },
+        {
+          value: -400,
+          label: '<-400'
+        },
         500,
         1000,
         2500,
         3000,
-        { value: 4500, label: '>4500' }
+        {
+          value: 4500,
+          label: '>4500'
+        }
       ],
     },
     Author: {
-      bounds: [1, 6],
+      bounds: [
+        1,
+        6
+      ],
       color_map: 'swissBEDROCK_Author',
-      steps: ['swisstopo', 'BE', 'GE', 'GLAMOS', 'VD', 'ZG'],
+      steps: [
+        'swisstopo',
+        'BE',
+        'GE',
+        'GLAMOS',
+        'VD',
+        'ZG'
+      ],
       is_discrete: true,
     },
     Uncertainty: {
-      bounds: [0, 25],
+      bounds: [
+        0,
+        25
+      ],
       color_map: 'swissBEDROCK_Uncertainty'
     }
   }

--- a/ui/src/features/layer/controllers/layer-tiff.controller.ts
+++ b/ui/src/features/layer/controllers/layer-tiff.controller.ts
@@ -199,6 +199,7 @@ export class TiffLayerController extends BaseLayerController<TiffLayer> {
       opacity: isStandalone ? this.layer.opacity : 1,
       canUpdateOpacity: isStandalone,
       isVisible: isStandalone ? this.layer.isVisible : true,
+      ogcSource: null,
     };
   }
 }

--- a/ui/src/features/layer/controllers/layer.controller.ts
+++ b/ui/src/features/layer/controllers/layer.controller.ts
@@ -4,6 +4,7 @@ import {
   LayerSource,
   LayerSourceType,
   LayerType,
+  OgcSourceType,
 } from 'src/features/layer';
 import { WmtsLayerController } from 'src/features/layer/controllers/layer-wmts.controller';
 import { Tiles3dLayerController } from 'src/features/layer/controllers/layer-tiles3d.controller';
@@ -445,10 +446,22 @@ export const mapLayerSourceToResource = async (
 
       // TODO At some point, we will have to differentiate between different formats.
       //      Right now, only 3dtiles can be fetched via OGC.
-      const url =
-        source.styleId === undefined
-          ? `https://ogc-api.gst-viewer.swissgeol.ch/collections/${source.id}/download_format/tiles3d`
-          : `https://ogc-api.gst-viewer.swissgeol.ch/collections/${source.id}/styles/${source.styleId}/download_format/tiles3d`;
+      const ogcSource = source.ogcSource;
+      let url: string;
+      switch (ogcSource.type) {
+        case OgcSourceType.Gst:
+          url = ogcSource.styleId
+            ? `https://ogc-api.gst-viewer.swissgeol.ch/collections/${ogcSource.id}/styles/${ogcSource.styleId}/download_format/tiles3d`
+            : `https://ogc-api.gst-viewer.swissgeol.ch/collections/${ogcSource.id}/download_format/tiles3d`;
+          break;
+        case OgcSourceType.Stac:
+          url = `https://ogc-api.gst-viewer.swissgeol.ch/collections/${ogcSource.collection}/download_format/tiles3d`;
+          break;
+        case OgcSourceType.Fdsn:
+        case OgcSourceType.Wms:
+          throw new Error(`Unsupported OGC source type: ${ogcSource.type}`);
+      }
+
       return new Resource({
         url,
         headers: {

--- a/ui/src/features/layer/layer-api.service.ts
+++ b/ui/src/features/layer/layer-api.service.ts
@@ -13,6 +13,8 @@ import {
   LayerSource,
   LayerSourceType,
   LayerType,
+  OgcSource,
+  OgcSourceType,
   TiffLayer,
   TiffLayerBand,
   TiffLayerConfigDisplay,
@@ -186,6 +188,10 @@ export class LayerApiService extends BaseService {
     return {
       ...def,
       maxLevel: config.takeNullable('maxLevel'),
+      ogcSource:
+        config
+          .takeNullableObject('ogcSource')
+          ?.apply(this.mapConfigToOgcSource) ?? null,
     };
   };
 
@@ -329,12 +335,40 @@ export class LayerApiService extends BaseService {
       case LayerSourceType.Ogc:
         return {
           type: LayerSourceType.Ogc,
-          id: config.take('id'),
-          styleId: config.takeNullable('styleId') ?? undefined,
+          ogcSource: config
+            .takeObject('ogcSource')
+            .apply(this.mapConfigToOgcSource),
           displaySource:
             config
               .takeNullableObject('displaySource')
               ?.apply(this.mapConfigToSource) ?? undefined,
+        };
+    }
+  };
+
+  private readonly mapConfigToOgcSource = (
+    config: DynamicObject,
+  ): OgcSource => {
+    const ogcType = config.take<OgcSourceType>('type');
+    switch (ogcType) {
+      case OgcSourceType.Gst:
+        return {
+          type: OgcSourceType.Gst,
+          id: config.take('id'),
+          styleId: config.takeNullable('styleId') ?? undefined,
+        };
+      case OgcSourceType.Stac:
+        return {
+          type: OgcSourceType.Stac,
+          collection: config.take('collection'),
+        };
+      case OgcSourceType.Fdsn:
+        return {
+          type: OgcSourceType.Fdsn,
+        };
+      case OgcSourceType.Wms:
+        return {
+          type: OgcSourceType.Wms,
         };
     }
   };

--- a/ui/src/features/layer/models/layer-wmts.model.ts
+++ b/ui/src/features/layer/models/layer-wmts.model.ts
@@ -1,4 +1,4 @@
-import { BaseLayer, LayerType } from 'src/features/layer';
+import { BaseLayer, LayerType, OgcSource } from 'src/features/layer';
 import type { Id } from 'src/models/id.model';
 
 /**
@@ -42,6 +42,11 @@ export interface WmtsLayer extends BaseLayer {
    * The name of the organization or entity that the layer is attributed to.
    */
   credit: string;
+
+  /**
+   * An optional source that will be used when exporting the layer via the OGC API.
+   */
+  ogcSource: OgcSource | null;
 }
 
 export interface WmtsLayerTimes {

--- a/ui/src/features/layer/models/source.ts
+++ b/ui/src/features/layer/models/source.ts
@@ -33,9 +33,15 @@ export interface LayerSourceForS3 {
   key: string;
 }
 
-export interface LayerSourceForOgc {
-  type: LayerSourceType.Ogc;
+export enum OgcSourceType {
+  Gst = 'gst',
+  Stac = 'stac',
+  Fdsn = 'fdsn',
+  Wms = 'wms',
+}
 
+interface OgcTypeForGst {
+  type: OgcSourceType.Gst;
   /**
    * The id of the collection representing the layer.
    */
@@ -46,7 +52,31 @@ export interface LayerSourceForOgc {
    * If left out, the collection's default download is used.
    */
   styleId?: number;
+}
 
+interface OgcTypeForStac {
+  type: OgcSourceType.Stac;
+  collection: string;
+}
+
+interface OgcTypeForWms {
+  type: OgcSourceType.Wms;
+}
+
+interface OgcTypeForFdsn {
+  type: OgcSourceType.Fdsn;
+}
+
+export type OgcSource =
+  | OgcTypeForGst
+  | OgcTypeForStac
+  | OgcTypeForFdsn
+  | OgcTypeForWms;
+
+export interface LayerSourceForOgc {
+  type: LayerSourceType.Ogc;
+
+  ogcSource: OgcSource;
   /**
    * An optional source that will be used when displaying the layer.
    * When this is set, the OGC API will only be used for layer exports.

--- a/ui/src/features/ogc/ogc.service.ts
+++ b/ui/src/features/ogc/ogc.service.ts
@@ -6,6 +6,7 @@ import {
   Layer,
   LayerSourceType,
   LayerType,
+  OgcSource,
   WmtsLayerSource,
 } from 'src/features/layer';
 import { Id } from 'src/models/id.model';
@@ -209,42 +210,17 @@ export class OgcService extends BaseService {
     };
 
     if (
-      layer.type === LayerType.Tiles3d &&
+      (layer.type === LayerType.Tiles3d || layer.type === LayerType.Tiff) &&
       layer.source.type === LayerSourceType.Ogc
     ) {
-      // A layer from the gst service, most likely a 3dtile.
-      const request = {
-        type: 'gst',
-        id: layer.source.id,
-
-        // The coordinate system used in the output file.
-        requestSrs: {
-          epsg: 4326,
-        },
-
-        // The volume that the output should take up.
-        // Unlike this WM(T)S layers, this is 3d.
-        requestVolume: {
-          ...requestArea,
-          polygon: {
-            points,
-            zMax: 100_000,
-            zMin: -100_000,
-          },
-        },
-      };
-      return [
-        {
-          ...request,
-          requestedFormat: 'gocad',
-        },
-        {
-          ...request,
-          requestedFormat: 'tiles3d',
-        },
-      ];
+      const ogcSource = layer.source.ogcSource;
+      return this.getOgcSourceForLayer(ogcSource, requestArea, points);
     }
     if (layer.type === LayerType.Wmts) {
+      // Some WMTS layers also have an OGC source, which should be preferred if available (GeoCover for example).
+      if (layer.ogcSource) {
+        return this.getOgcSourceForLayer(layer.ogcSource, requestArea, points);
+      }
       switch (layer.source) {
         case WmtsLayerSource.WMS:
           return [
@@ -273,6 +249,62 @@ export class OgcService extends BaseService {
       );
     }
     return [];
+  }
+
+  private getOgcSourceForLayer(
+    ogcSource: OgcSource,
+    requestArea: { srs: { epsg: number }; polygon: number[][] },
+    points: number[][],
+  ): object[] {
+    switch (ogcSource.type) {
+      case 'gst': {
+        const request = {
+          type: 'gst',
+          id: ogcSource.id,
+
+          // The coordinate system used in the output file.
+          requestSrs: {
+            epsg: 4326,
+          },
+
+          // The volume that the output should take up.
+          // Unlike this WM(T)S layers, this is 3d.
+          requestVolume: {
+            ...requestArea,
+            polygon: {
+              points,
+              zMax: 100_000,
+              zMin: -100_000,
+            },
+          },
+        };
+        return [
+          {
+            ...request,
+            requestedFormat: 'gocad',
+          },
+          {
+            ...request,
+            requestedFormat: 'tiles3d',
+          },
+        ];
+      }
+      case 'stac': {
+        return [
+          {
+            type: 'stac09',
+            collection: ogcSource.collection,
+            identifier: 'stac@swisstopo',
+            requestArea,
+          },
+        ];
+      }
+      case 'fdsn':
+      case 'wms':
+      default:
+        // Not yet implemented
+        return [];
+    }
   }
 }
 

--- a/ui/src/services/wmts.service.ts
+++ b/ui/src/services/wmts.service.ts
@@ -112,6 +112,7 @@ export class WmtsService extends BaseService {
         credit: layerName.split('.')[1],
         times: this.makeTimes(defaultTimestamp, timestamps),
         customProperties: {},
+        ogcSource: null,
       });
     }
     return configs;
@@ -177,6 +178,7 @@ export class WmtsService extends BaseService {
           credit: layerName.split('.')[1],
           times: this.makeTimes(defaultTimestamp, timestamps),
           customProperties: {},
+          ogcSource: null,
         });
       }
     }


### PR DESCRIPTION
resolves #1758

Allows to target the STAC source from the OGC API. The same layertype can have different OGC source Tyes, so a new property OgcSource was added to defined the source per layer