### PR TITLE
Feature/viewer 1836 poc seismik slider

### DIFF
--- a/ui/src/features/catalog/catalog.module.ts
+++ b/ui/src/features/catalog/catalog.module.ts
@@ -5,6 +5,7 @@ import './display/details/catalog-display-times-detail.element';
 import './display/details/catalog-display-tiff-bands.element';
 import './display/details/catalog-display-tiff-legend.element';
 import './display/details/catalog-display-voxel-filter-detail.element';
+import './display/details/catalog-display-slice-detail.element';
 
 import './tree/catalog-tree.element';
 import './tree/catalog-tree-group.element';

--- a/ui/src/features/catalog/display/catalog-display-list-item.element.ts
+++ b/ui/src/features/catalog/display/catalog-display-list-item.element.ts
@@ -155,6 +155,20 @@ export class CatalogDisplayListItem extends CoreElement {
       `,
     });
 
+  private readonly openSlice = (): void =>
+    this.openWindow('slice', {
+      title: () =>
+        i18next.t('catalog:slice_window.title', {
+          defaultValue: 'Slice Selection',
+          layer: getLayerLabel(this.layer),
+        }),
+      body: () => html`
+        <ngm-catalog-display-slice-detail
+          .layerId=${this.layer.id}
+        ></ngm-catalog-display-slice-detail>
+      `,
+    });
+
   private readonly handleOpacityChangeEvent = throttle(
     (event: SliderChangeEvent): void => {
       this.layerService.update(this.layerId, { opacity: event.detail.value });
@@ -184,17 +198,6 @@ export class CatalogDisplayListItem extends CoreElement {
         </ngm-core-button>
 
         <span class="title">${title}</span>
-        <button
-          @click="${async () => {
-            const a = this.layerService.controller(
-              this.layer.id,
-            ) as Tiles3dLayerController;
-            await a.updateSlices([30, 500, 900]);
-          }}"
-        >
-          Change Slices
-        </button>
-
         <div class="suffix">
           ${when(
             isBackgroundLayer(this.layer),
@@ -295,6 +298,22 @@ export class CatalogDisplayListItem extends CoreElement {
           >
             <ngm-core-icon icon="filter"></ngm-core-icon>
             ${i18next.t('catalog:display.filter')}
+          </ngm-core-dropdown-item>
+        `,
+      )}
+      ${when(
+        this.layer.type === LayerType.Tiles3d &&
+          (
+            this.layerService.controller(
+              this.layer.id,
+            ) as Tiles3dLayerController
+          )?.supportsSliceSelection,
+        () => html`
+          <ngm-core-dropdown-item role="button" @click="${this.openSlice}">
+            <ngm-core-icon icon="filter"></ngm-core-icon>
+            ${i18next.t('catalog:display.slice', {
+              defaultValue: 'Slice',
+            })}
           </ngm-core-dropdown-item>
         `,
       )}
@@ -512,7 +531,7 @@ export class CatalogDisplayListItem extends CoreElement {
   `;
 }
 
-type WindowName = 'legend' | 'times' | 'voxelFilter' | 'tiffFilter';
+type WindowName = 'legend' | 'times' | 'voxelFilter' | 'tiffFilter' | 'slice';
 
 type WindowMapping = Record<WindowName, CoreWindow | null>;
 
@@ -536,6 +555,7 @@ const getWindowsOfLayer = (layerId: Id<AnyLayer>): WindowMapping => {
     tiffFilter: null,
     times: null,
     voxelFilter: null,
+    slice: null,
   };
   windowMappingsByLayerId.set(layerId, newMapping);
   return newMapping;

--- a/ui/src/features/catalog/display/catalog-display-list-item.element.ts
+++ b/ui/src/features/catalog/display/catalog-display-list-item.element.ts
@@ -14,6 +14,7 @@ import {
   isBackgroundLayer,
   Layer,
   LayerType,
+  Tiles3dLayerController,
 } from 'src/features/layer';
 import { css, html } from 'lit';
 import { Id } from 'src/models/id.model';
@@ -183,6 +184,16 @@ export class CatalogDisplayListItem extends CoreElement {
         </ngm-core-button>
 
         <span class="title">${title}</span>
+        <button
+          @click="${async () => {
+            const a = this.layerService.controller(
+              this.layer.id,
+            ) as Tiles3dLayerController;
+            await a.updateSlices([30, 500, 900]);
+          }}"
+        >
+          Change Slices
+        </button>
 
         <div class="suffix">
           ${when(

--- a/ui/src/features/catalog/display/details/catalog-display-slice-detail.element.ts
+++ b/ui/src/features/catalog/display/details/catalog-display-slice-detail.element.ts
@@ -19,7 +19,7 @@ export class CatalogDisplaySliceDetail extends CoreElement {
   accessor layer!: Tiles3dLayer;
 
   @state()
-  accessor currentSliceIndex = 0;
+  accessor sliceIndices: [number, number, number] = [0, 0, 0];
 
   @state()
   accessor controller: Tiles3dLayerController | null = null;
@@ -39,31 +39,45 @@ export class CatalogDisplaySliceDetail extends CoreElement {
           layer.id,
         ) as Tiles3dLayerController;
 
-        // Initialize slice index
+        // Initialize slice indices
         if (this.controller?.supportsSliceSelection) {
-          const availableSlices = this.controller.getAvailableSlices();
-          this.currentSliceIndex = Math.floor(availableSlices.length / 2);
+          this.sliceIndices = this.controller.getCurrentSliceIndices();
         }
       }),
     );
   }
 
-  private readonly handleSliceChangeEvent = throttle(
+  private readonly handleAufschnitteChange = throttle(
     (event: SliderChangeEvent): void => {
-      if (!this.controller) {
-        return;
-      }
+      if (!this.controller) return;
 
-      const availableSlices = this.controller.getAvailableSlices();
       const index = Math.round(event.detail.value);
-      this.currentSliceIndex = index;
-
-      if (availableSlices.length > 0 && index < availableSlices.length) {
-        const sliceNumber = availableSlices[index];
-        this.controller.updateSlices([sliceNumber]);
-      }
+      this.sliceIndices = [index, this.sliceIndices[1], this.sliceIndices[2]];
+      this.controller.updateSliceAtIndex(0, index);
     },
-    200,
+    500,
+  );
+
+  private readonly handleSeitenansichtenChange = throttle(
+    (event: SliderChangeEvent): void => {
+      if (!this.controller) return;
+
+      const index = Math.round(event.detail.value);
+      this.sliceIndices = [this.sliceIndices[0], index, this.sliceIndices[2]];
+      this.controller.updateSliceAtIndex(1, index);
+    },
+    500,
+  );
+
+  private readonly handleQuerschnitteChange = throttle(
+    (event: SliderChangeEvent): void => {
+      if (!this.controller) return;
+
+      const index = Math.round(event.detail.value);
+      this.sliceIndices = [this.sliceIndices[0], this.sliceIndices[1], index];
+      this.controller.updateSliceAtIndex(2, index);
+    },
+    500,
   );
 
   readonly render = () => {
@@ -76,24 +90,80 @@ export class CatalogDisplaySliceDetail extends CoreElement {
       return html``;
     }
 
-    const currentSlice = availableSlices[this.currentSliceIndex] ?? 0;
-    const minIndex = 0;
-    const maxIndex = availableSlices.length - 1;
+    const ranges = this.controller.getSliceRanges();
+
+    // Calculate current slice numbers for each category
+    const aufschnitteSlice =
+      availableSlices[ranges[0].start + this.sliceIndices[0]] ?? 0;
+    const seitenansichtenSlice =
+      availableSlices[ranges[1].start + this.sliceIndices[1]] ?? 0;
+    const querschnitteSlice =
+      availableSlices[ranges[2].start + this.sliceIndices[2]] ?? 0;
 
     return html`
       <div class="slice-control">
-        <div class="slice-info">
-          <span class="slice-label">
-            ${i18next.t('catalog:slice_window.current_slice', {
-              defaultValue: 'Current Slice',
-            })}:
-          </span>
-          <span class="slice-value">${currentSlice}</span>
+        <!-- Aufschnitte Slider -->
+        <div class="slice-category">
+          <div class="slice-info">
+            <span class="slice-label">
+              ${i18next.t('catalog:slice_window.aufschnitte', {
+                defaultValue: 'Aufschnitte',
+              })}
+            </span>
+            <span class="slice-value">${aufschnitteSlice}</span>
+          </div>
+          <ngm-core-slider
+            .value="${this.sliceIndices[0]}"
+            .min="${0}"
+            .max="${ranges[0].end - ranges[0].start}"
+            .step="${1}"
+            @change="${this.handleAufschnitteChange}"
+          ></ngm-core-slider>
         </div>
+
+        <!-- Seitenansichten Slider -->
+        <div class="slice-category">
+          <div class="slice-info">
+            <span class="slice-label">
+              ${i18next.t('catalog:slice_window.seitenansichten', {
+                defaultValue: 'Seitenansichten',
+              })}
+            </span>
+            <span class="slice-value">${seitenansichtenSlice}</span>
+          </div>
+          <ngm-core-slider
+            .value="${this.sliceIndices[1]}"
+            .min="${0}"
+            .max="${ranges[1].end - ranges[1].start}"
+            .step="${1}"
+            @change="${this.handleSeitenansichtenChange}"
+          ></ngm-core-slider>
+        </div>
+
+        <!-- Querschnitte Slider -->
+        <div class="slice-category">
+          <div class="slice-info">
+            <span class="slice-label">
+              ${i18next.t('catalog:slice_window.querschnitte', {
+                defaultValue: 'Querschnitte',
+              })}
+            </span>
+            <span class="slice-value">${querschnitteSlice}</span>
+          </div>
+          <ngm-core-slider
+            .value="${this.sliceIndices[2]}"
+            .min="${0}"
+            .max="${ranges[2].end - ranges[2].start}"
+            .step="${1}"
+            @change="${this.handleQuerschnitteChange}"
+          ></ngm-core-slider>
+        </div>
+
+        <!-- Overall Range Info -->
         <div class="slice-range">
           <span class="range-label">
-            ${i18next.t('catalog:slice_window.range', {
-              defaultValue: 'Range',
+            ${i18next.t('catalog:slice_window.total_range', {
+              defaultValue: 'Gesamtbereich',
             })}:
           </span>
           <span class="range-value">
@@ -101,13 +171,6 @@ export class CatalogDisplaySliceDetail extends CoreElement {
             ${availableSlices[availableSlices.length - 1]}
           </span>
         </div>
-        <ngm-core-slider
-          .value="${this.currentSliceIndex}"
-          .min="${minIndex}"
-          .max="${maxIndex}"
-          .step="${1}"
-          @change="${this.handleSliceChangeEvent}"
-        ></ngm-core-slider>
       </div>
     `;
   };
@@ -126,7 +189,19 @@ export class CatalogDisplaySliceDetail extends CoreElement {
     .slice-control {
       display: flex;
       flex-direction: column;
-      gap: 16px;
+      gap: 24px;
+    }
+
+    .slice-category {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      padding: 12px;
+      border-radius: 4px;
+      background-color: var(
+        --color-background--emphasis-low,
+        rgba(0, 0, 0, 0.02)
+      );
     }
 
     .slice-info,
@@ -151,6 +226,12 @@ export class CatalogDisplaySliceDetail extends CoreElement {
     .range-value {
       ${applyTypography('body-2')};
       color: var(--color-text--emphasis-high);
+    }
+
+    .slice-range {
+      padding-top: 8px;
+      border-top: 1px solid
+        var(--color-border--emphasis-low, rgba(0, 0, 0, 0.1));
     }
   `;
 }

--- a/ui/src/features/catalog/display/details/catalog-display-slice-detail.element.ts
+++ b/ui/src/features/catalog/display/details/catalog-display-slice-detail.element.ts
@@ -1,0 +1,156 @@
+import { css, html } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import { CoreElement } from 'src/features/core';
+import { Tiles3dLayer, Tiles3dLayerController } from 'src/features/layer';
+import { consume } from '@lit/context';
+import { LayerService } from 'src/features/layer/layer.service';
+import { Id } from 'src/models/id.model';
+import { SliderChangeEvent } from 'src/features/core/core-slider.element';
+import { throttle } from 'src/utils/fn.utils';
+import { applyTypography } from 'src/styles/theme';
+import i18next from 'i18next';
+
+@customElement('ngm-catalog-display-slice-detail')
+export class CatalogDisplaySliceDetail extends CoreElement {
+  @property()
+  accessor layerId!: Id<Tiles3dLayer>;
+
+  @state()
+  accessor layer!: Tiles3dLayer;
+
+  @state()
+  accessor currentSliceIndex = 0;
+
+  @state()
+  accessor controller: Tiles3dLayerController | null = null;
+
+  @consume({ context: LayerService.context() })
+  accessor layerService!: LayerService;
+
+  connectedCallback(): void {
+    super.connectedCallback();
+
+    this.register(
+      this.layerService.layer$(this.layerId).subscribe((layer) => {
+        this.layer = layer;
+
+        // Get and store controller
+        this.controller = this.layerService.controller(
+          layer.id,
+        ) as Tiles3dLayerController;
+
+        // Initialize slice index
+        if (this.controller?.supportsSliceSelection) {
+          const availableSlices = this.controller.getAvailableSlices();
+          this.currentSliceIndex = Math.floor(availableSlices.length / 2);
+        }
+      }),
+    );
+  }
+
+  private readonly handleSliceChangeEvent = throttle(
+    (event: SliderChangeEvent): void => {
+      if (!this.controller) {
+        return;
+      }
+
+      const availableSlices = this.controller.getAvailableSlices();
+      const index = Math.round(event.detail.value);
+      this.currentSliceIndex = index;
+
+      if (availableSlices.length > 0 && index < availableSlices.length) {
+        const sliceNumber = availableSlices[index];
+        this.controller.updateSlices([sliceNumber]);
+      }
+    },
+    200,
+  );
+
+  readonly render = () => {
+    if (!this.controller || !this.controller.supportsSliceSelection) {
+      return html``;
+    }
+
+    const availableSlices = this.controller.getAvailableSlices();
+    if (availableSlices.length === 0) {
+      return html``;
+    }
+
+    const currentSlice = availableSlices[this.currentSliceIndex] ?? 0;
+    const minIndex = 0;
+    const maxIndex = availableSlices.length - 1;
+
+    return html`
+      <div class="slice-control">
+        <div class="slice-info">
+          <span class="slice-label">
+            ${i18next.t('catalog:slice_window.current_slice', {
+              defaultValue: 'Current Slice',
+            })}:
+          </span>
+          <span class="slice-value">${currentSlice}</span>
+        </div>
+        <div class="slice-range">
+          <span class="range-label">
+            ${i18next.t('catalog:slice_window.range', {
+              defaultValue: 'Range',
+            })}:
+          </span>
+          <span class="range-value">
+            ${availableSlices[0]} -
+            ${availableSlices[availableSlices.length - 1]}
+          </span>
+        </div>
+        <ngm-core-slider
+          .value="${this.currentSliceIndex}"
+          .min="${minIndex}"
+          .max="${maxIndex}"
+          .step="${1}"
+          @change="${this.handleSliceChangeEvent}"
+        ></ngm-core-slider>
+      </div>
+    `;
+  };
+
+  static readonly styles = css`
+    :host,
+    :host * {
+      box-sizing: border-box;
+    }
+
+    :host {
+      display: block;
+      padding: 16px;
+    }
+
+    .slice-control {
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+    }
+
+    .slice-info,
+    .slice-range {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+
+    .slice-label,
+    .range-label {
+      ${applyTypography('body-2')};
+      color: var(--color-text--emphasis-medium);
+    }
+
+    .slice-value {
+      ${applyTypography('h5')};
+      color: var(--color-text--emphasis-high);
+      font-weight: 600;
+    }
+
+    .range-value {
+      ${applyTypography('body-2')};
+      color: var(--color-text--emphasis-high);
+    }
+  `;
+}

--- a/ui/src/features/catalog/display/details/catalog-display-slice-detail.element.ts
+++ b/ui/src/features/catalog/display/details/catalog-display-slice-detail.element.ts
@@ -1,7 +1,11 @@
 import { css, html } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { CoreElement } from 'src/features/core';
-import { Tiles3dLayer, Tiles3dLayerController } from 'src/features/layer';
+import {
+  Tiles3dLayer,
+  Tiles3dLayerController,
+  SliceIndices,
+} from 'src/features/layer';
 import { consume } from '@lit/context';
 import { LayerService } from 'src/features/layer/layer.service';
 import { Id } from 'src/models/id.model';
@@ -19,7 +23,11 @@ export class CatalogDisplaySliceDetail extends CoreElement {
   accessor layer!: Tiles3dLayer;
 
   @state()
-  accessor sliceIndices: [number, number, number] = [0, 0, 0];
+  accessor sliceIndices: SliceIndices = {
+    inline: 0,
+    crossline: 0,
+    depth: 0,
+  };
 
   @state()
   accessor controller: Tiles3dLayerController | null = null;
@@ -34,12 +42,10 @@ export class CatalogDisplaySliceDetail extends CoreElement {
       this.layerService.layer$(this.layerId).subscribe((layer) => {
         this.layer = layer;
 
-        // Get and store controller
         this.controller = this.layerService.controller(
           layer.id,
         ) as Tiles3dLayerController;
 
-        // Initialize slice indices
         if (this.controller?.supportsSliceSelection) {
           this.sliceIndices = this.controller.getCurrentSliceIndices();
         }
@@ -47,38 +53,17 @@ export class CatalogDisplaySliceDetail extends CoreElement {
     );
   }
 
-  private readonly handleAufschnitteChange = throttle(
-    (event: SliderChangeEvent): void => {
+  private readonly handleSliceChange = (key: keyof SliceIndices) =>
+    throttle((event: SliderChangeEvent): void => {
       if (!this.controller) return;
 
       const index = Math.round(event.detail.value);
-      this.sliceIndices = [index, this.sliceIndices[1], this.sliceIndices[2]];
-      this.controller.updateSliceAtIndex(0, index);
-    },
-    500,
-  );
-
-  private readonly handleSeitenansichtenChange = throttle(
-    (event: SliderChangeEvent): void => {
-      if (!this.controller) return;
-
-      const index = Math.round(event.detail.value);
-      this.sliceIndices = [this.sliceIndices[0], index, this.sliceIndices[2]];
-      this.controller.updateSliceAtIndex(1, index);
-    },
-    500,
-  );
-
-  private readonly handleQuerschnitteChange = throttle(
-    (event: SliderChangeEvent): void => {
-      if (!this.controller) return;
-
-      const index = Math.round(event.detail.value);
-      this.sliceIndices = [this.sliceIndices[0], this.sliceIndices[1], index];
-      this.controller.updateSliceAtIndex(2, index);
-    },
-    500,
-  );
+      this.sliceIndices = {
+        ...this.sliceIndices,
+        [key]: index,
+      };
+      this.controller.updateSliceAtIndex(key, index);
+    }, 500);
 
   readonly render = () => {
     if (!this.controller || !this.controller.supportsSliceSelection) {
@@ -92,17 +77,16 @@ export class CatalogDisplaySliceDetail extends CoreElement {
 
     const ranges = this.controller.getSliceRanges();
 
-    // Calculate current slice numbers for each category
-    const aufschnitteSlice =
-      availableSlices[ranges[0].start + this.sliceIndices[0]] ?? 0;
-    const seitenansichtenSlice =
-      availableSlices[ranges[1].start + this.sliceIndices[1]] ?? 0;
-    const querschnitteSlice =
-      availableSlices[ranges[2].start + this.sliceIndices[2]] ?? 0;
+    const inlineSlice =
+      availableSlices[ranges.inline.start + this.sliceIndices.inline] ?? 0;
+    const crosslineSlice =
+      availableSlices[ranges.crossline.start + this.sliceIndices.crossline] ??
+      0;
+    const depthSlice =
+      availableSlices[ranges.depth.start + this.sliceIndices.depth] ?? 0;
 
     return html`
       <div class="slice-control">
-        <!-- Aufschnitte Slider -->
         <div class="slice-category">
           <div class="slice-info">
             <span class="slice-label">
@@ -110,18 +94,17 @@ export class CatalogDisplaySliceDetail extends CoreElement {
                 defaultValue: 'Aufschnitte',
               })}
             </span>
-            <span class="slice-value">${aufschnitteSlice}</span>
+            <span class="slice-value">${inlineSlice}</span>
           </div>
           <ngm-core-slider
-            .value="${this.sliceIndices[0]}"
+            .value="${this.sliceIndices.inline}"
             .min="${0}"
-            .max="${ranges[0].end - ranges[0].start}"
+            .max="${ranges.inline.end - ranges.inline.start}"
             .step="${1}"
-            @change="${this.handleAufschnitteChange}"
+            @change="${this.handleSliceChange('inline')}"
           ></ngm-core-slider>
         </div>
 
-        <!-- Seitenansichten Slider -->
         <div class="slice-category">
           <div class="slice-info">
             <span class="slice-label">
@@ -129,18 +112,17 @@ export class CatalogDisplaySliceDetail extends CoreElement {
                 defaultValue: 'Seitenansichten',
               })}
             </span>
-            <span class="slice-value">${seitenansichtenSlice}</span>
+            <span class="slice-value">${crosslineSlice}</span>
           </div>
           <ngm-core-slider
-            .value="${this.sliceIndices[1]}"
+            .value="${this.sliceIndices.crossline}"
             .min="${0}"
-            .max="${ranges[1].end - ranges[1].start}"
+            .max="${ranges.crossline.end - ranges.crossline.start}"
             .step="${1}"
-            @change="${this.handleSeitenansichtenChange}"
+            @change="${this.handleSliceChange('crossline')}"
           ></ngm-core-slider>
         </div>
 
-        <!-- Querschnitte Slider -->
         <div class="slice-category">
           <div class="slice-info">
             <span class="slice-label">
@@ -148,14 +130,14 @@ export class CatalogDisplaySliceDetail extends CoreElement {
                 defaultValue: 'Querschnitte',
               })}
             </span>
-            <span class="slice-value">${querschnitteSlice}</span>
+            <span class="slice-value">${depthSlice}</span>
           </div>
           <ngm-core-slider
-            .value="${this.sliceIndices[2]}"
+            .value="${this.sliceIndices.depth}"
             .min="${0}"
-            .max="${ranges[2].end - ranges[2].start}"
+            .max="${ranges.depth.end - ranges.depth.start}"
             .step="${1}"
-            @change="${this.handleQuerschnitteChange}"
+            @change="${this.handleSliceChange('depth')}"
           ></ngm-core-slider>
         </div>
 

--- a/ui/src/features/layer/controllers/layer-tiles3d.controller.ts
+++ b/ui/src/features/layer/controllers/layer-tiles3d.controller.ts
@@ -10,6 +10,7 @@ import {
   CustomShaderTranslucencyMode,
   ImageBasedLighting,
   UniformType,
+  Resource,
 } from 'cesium';
 import { OBJECT_HIGHLIGHT_NORMALIZED_RGB } from 'src/constants';
 import { PickService, ScenePickingLock } from 'src/services/pick.service';
@@ -56,7 +57,33 @@ export class Tiles3dLayerController extends BaseLayerController<Tiles3dLayer> {
 
   protected async addToViewer(): Promise<void> {
     const resource = await mapLayerSourceToResource(this.layer.source);
-    const tileset = await Cesium3DTileset.fromUrl(resource, {
+    let tilesetUrl: string;
+
+    if (this.layer.source.type === 'Ogc') {
+      const token = import.meta.env['VITE_OGC_GST_BASIC_AUTH'];
+      const originalFetch = Resource.prototype.fetch;
+      Resource.prototype.fetch = function (options) {
+        this.headers = {
+          ...(this.headers || {}),
+          Authorization: `Basic ${token}`,
+        };
+        return originalFetch.call(this, options);
+      };
+      // For OGC sources, fetch the tileset JSON, prune it, and create a blob URL
+      const tilesetJson = await resource.fetchJson();
+      const keepSlices = new Set([227, 245, 348]);
+      const prunedTileset = makePrunedTileset(
+        tilesetJson,
+        keepSlices,
+        resource.url,
+      );
+      tilesetUrl = toBlobUrl(prunedTileset);
+    } else {
+      // For other sources, use the resource URL directly
+      tilesetUrl = resource.url;
+    }
+
+    const tileset = await Cesium3DTileset.fromUrl(tilesetUrl, {
       show: true,
       backFaceCulling: false,
       enableCollision: true,
@@ -168,4 +195,59 @@ export class Tiles3dLayerController extends BaseLayerController<Tiles3dLayer> {
       },
     });
   }
+}
+
+function parseSlice(uri: string): number | null {
+  const m = uri.match(/-slice-(\d+)\.glb$/);
+  return m ? Number(m[1]) : null;
+}
+
+function makePrunedTileset(
+  original: any,
+  keepSlices: Set<number>,
+  baseUrl: string,
+): any {
+  const clone = structuredClone(original);
+
+  const prune = (tile: any): any | null => {
+    let keep = false;
+
+    const uri = tile?.content?.uri;
+    if (uri) {
+      const slice = parseSlice(uri);
+      if (slice !== null && keepSlices.has(slice)) {
+        keep = true;
+        // Convert relative URI to absolute URI
+        tile.content.uri = new URL(uri, baseUrl).href;
+      }
+    }
+
+    if (tile?.children?.length) {
+      const keptChildren = tile.children
+        .map(prune)
+        .filter((x: any) => x !== null);
+
+      tile.children = keptChildren;
+      if (keptChildren.length > 0) keep = true;
+    }
+
+    return keep ? tile : null;
+  };
+
+  const newRoot = prune(clone.root);
+  if (!newRoot) {
+    throw new Error('None of the selected slices were found in the tileset.');
+  }
+
+  clone.root = newRoot;
+
+  // IMPORTANT: keep original geometricError values
+  // This is crucial for Cesium to traverse the tree
+
+  return clone;
+}
+
+function toBlobUrl(json: any): string {
+  const blob = new Blob([JSON.stringify(json)], { type: 'application/json' });
+  return URL.createObjectURL(blob);
 }

--- a/ui/src/features/layer/controllers/layer-tiles3d.controller.ts
+++ b/ui/src/features/layer/controllers/layer-tiles3d.controller.ts
@@ -21,6 +21,9 @@ export class Tiles3dLayerController extends BaseLayerController<Tiles3dLayer> {
   private scenePickingLock: ScenePickingLock | null = null;
   private originalTilesetJson: any = null;
   private baseUrl: string = '';
+  private availableSlices: number[] = [];
+  private isUpdatingSlices: boolean = false;
+  private pendingSliceUpdate: number[] | null = null;
 
   get type(): LayerType.Tiles3d {
     return LayerType.Tiles3d;
@@ -28,6 +31,20 @@ export class Tiles3dLayerController extends BaseLayerController<Tiles3dLayer> {
 
   get tileset(): Cesium3DTileset {
     return this._tileset;
+  }
+
+  /**
+   * Get all available slice numbers for OGC tileset sources.
+   */
+  getAvailableSlices(): number[] {
+    return this.availableSlices;
+  }
+
+  /**
+   * Check if this layer supports slice selection.
+   */
+  get supportsSliceSelection(): boolean {
+    return this.layer.source.type === 'Ogc' && this.availableSlices.length > 0;
   }
 
   zoomIntoView(): void {
@@ -53,6 +70,34 @@ export class Tiles3dLayerController extends BaseLayerController<Tiles3dLayer> {
       return;
     }
 
+    // If already updating, store this as pending update and return
+    if (this.isUpdatingSlices) {
+      this.pendingSliceUpdate = sliceNumbers;
+      return;
+    }
+
+    // Mark as updating
+    this.isUpdatingSlices = true;
+
+    try {
+      await this.performSliceUpdate(sliceNumbers);
+
+      // Check if there's a pending update
+      while (this.pendingSliceUpdate !== null) {
+        const nextSlices = this.pendingSliceUpdate;
+        this.pendingSliceUpdate = null;
+        await this.performSliceUpdate(nextSlices);
+      }
+    } finally {
+      // Always clear the updating flag
+      this.isUpdatingSlices = false;
+    }
+  }
+
+  /**
+   * Perform the actual slice update.
+   */
+  private async performSliceUpdate(sliceNumbers: number[]): Promise<void> {
     // Create pruned tileset with new slices
     const keepSlices = new Set(sliceNumbers);
     const prunedTileset = makePrunedTileset(
@@ -67,10 +112,13 @@ export class Tiles3dLayerController extends BaseLayerController<Tiles3dLayer> {
     const currentVisibility = this.layer.isVisible;
     const currentIndex = this.findIndexInPrimitives(this.tileset);
 
-    // Remove old tileset
-    this.viewer.scene.primitives.remove(this.tileset);
-    if (!this.tileset.isDestroyed()) {
-      this.tileset.destroy();
+    // Properly remove old tileset
+    if (this.tileset) {
+      this.viewer.scene.primitives.remove(this.tileset);
+
+      if (!this.tileset.isDestroyed()) {
+        this.tileset.destroy();
+      }
     }
 
     // Create new tileset with updated slices
@@ -110,6 +158,12 @@ export class Tiles3dLayerController extends BaseLayerController<Tiles3dLayer> {
       tileset.customShader?.setUniform('u_alpha', currentOpacity);
     }
 
+    // Release old picking lock
+    if (this.scenePickingLock) {
+      this.scenePickingLock.release();
+      this.scenePickingLock = null;
+    }
+
     // Set up load progress tracking
     const pickService = PickService.get();
     this.scenePickingLock = pickService.acquireScenePickingLock();
@@ -123,6 +177,32 @@ export class Tiles3dLayerController extends BaseLayerController<Tiles3dLayer> {
         }
       },
     );
+  }
+
+  /**
+   * Extract all available slice numbers from the tileset JSON.
+   */
+  private extractAvailableSlices(tilesetJson: any): number[] {
+    const slices: number[] = [];
+
+    const traverse = (tile: any): void => {
+      const uri = tile?.content?.uri;
+      if (uri) {
+        const slice = parseSlice(uri);
+        if (slice !== null) {
+          slices.push(slice);
+        }
+      }
+      if (tile?.children?.length) {
+        tile.children.forEach(traverse);
+      }
+    };
+
+    if (tilesetJson?.root) {
+      traverse(tilesetJson.root);
+    }
+
+    return slices.sort((a, b) => a - b);
   }
 
   protected reactToChanges(): void {
@@ -163,7 +243,15 @@ export class Tiles3dLayerController extends BaseLayerController<Tiles3dLayer> {
       this.originalTilesetJson = tilesetJson;
       this.baseUrl = resource.url;
 
-      const keepSlices = new Set([1000]);
+      // Extract all available slices
+      this.availableSlices = this.extractAvailableSlices(tilesetJson);
+
+      // Start with the middle slice
+      const middleIndex = Math.floor(this.availableSlices.length / 2);
+      const initialSlice =
+        this.availableSlices.length > 0 ? this.availableSlices[middleIndex] : 0;
+
+      const keepSlices = new Set([initialSlice]);
       const prunedTileset = makePrunedTileset(
         tilesetJson,
         keepSlices,
@@ -290,7 +378,7 @@ export class Tiles3dLayerController extends BaseLayerController<Tiles3dLayer> {
 }
 
 function parseSlice(uri: string): number | null {
-  const m = uri.match(/-slice-(\d+)\.glb$/);
+  const m = /-slice-(\d+)\.glb$/.exec(uri);
   return m ? Number(m[1]) : null;
 }
 

--- a/ui/src/features/layer/controllers/layer-tiles3d.controller.ts
+++ b/ui/src/features/layer/controllers/layer-tiles3d.controller.ts
@@ -22,8 +22,10 @@ export class Tiles3dLayerController extends BaseLayerController<Tiles3dLayer> {
   private originalTilesetJson: any = null;
   private baseUrl: string = '';
   private availableSlices: number[] = [];
+  private currentBlobUrl: string | null = null;
   private isUpdatingSlices: boolean = false;
   private pendingSliceUpdate: number[] | null = null;
+  private currentSliceIndices: [number, number, number] = [0, 0, 0]; // Indices for the three sliders
 
   get type(): LayerType.Tiles3d {
     return LayerType.Tiles3d;
@@ -38,6 +40,66 @@ export class Tiles3dLayerController extends BaseLayerController<Tiles3dLayer> {
    */
   getAvailableSlices(): number[] {
     return this.availableSlices;
+  }
+
+  /**
+   * Get the slice ranges for the three categories.
+   * Returns [aufschnitte, seitenansichten, querschnitte] ranges.
+   * Will be removed once we get the ranges from the backend
+   */
+  getSliceRanges(): [
+    { start: number; end: number },
+    { start: number; end: number },
+    { start: number; end: number },
+  ] {
+    const total = this.availableSlices.length;
+    const third = Math.floor(total / 3);
+
+    return [
+      { start: 0, end: third - 1 },
+      { start: third, end: 2 * third - 1 },
+      { start: 2 * third, end: total - 1 },
+    ];
+  }
+
+  /**
+   * Get current slice indices for the three sliders.
+   */
+  getCurrentSliceIndices(): [number, number, number] {
+    return this.currentSliceIndices;
+  }
+
+  /**
+   * Update a specific slider's slice index.
+   * @param sliderIndex - 0 for Aufschnitte, 1 for Seitenansichten, 2 for Querschnitte
+   * @param index - The new index value
+   */
+  async updateSliceAtIndex(
+    sliderIndex: 0 | 1 | 2,
+    index: number,
+  ): Promise<void> {
+    this.currentSliceIndices[sliderIndex] = index;
+
+    // Get all three slice numbers
+    const ranges = this.getSliceRanges();
+    const sliceNumbers: number[] = [];
+
+    for (let i = 0; i < 3; i++) {
+      const range = ranges[i];
+      const localIndex = this.currentSliceIndices[i];
+      const globalIndex = range.start + localIndex;
+
+      if (
+        globalIndex >= 0 &&
+        globalIndex < this.availableSlices.length &&
+        globalIndex >= range.start &&
+        globalIndex <= range.end
+      ) {
+        sliceNumbers.push(this.availableSlices[globalIndex]);
+      }
+    }
+
+    await this.updateSlices(sliceNumbers);
   }
 
   /**
@@ -120,6 +182,15 @@ export class Tiles3dLayerController extends BaseLayerController<Tiles3dLayer> {
         this.tileset.destroy();
       }
     }
+
+    // Release old blob URL
+    if (this.currentBlobUrl) {
+      URL.revokeObjectURL(this.currentBlobUrl);
+      this.currentBlobUrl = null;
+    }
+
+    // Store new blob URL
+    this.currentBlobUrl = tilesetUrl;
 
     // Create new tileset with updated slices
     const tileset = await Cesium3DTileset.fromUrl(tilesetUrl, {
@@ -246,18 +317,29 @@ export class Tiles3dLayerController extends BaseLayerController<Tiles3dLayer> {
       // Extract all available slices
       this.availableSlices = this.extractAvailableSlices(tilesetJson);
 
-      // Start with the middle slice
-      const middleIndex = Math.floor(this.availableSlices.length / 2);
-      const initialSlice =
-        this.availableSlices.length > 0 ? this.availableSlices[middleIndex] : 0;
+      // Initialize the three sliders to their middle positions
+      const ranges = this.getSliceRanges();
+      this.currentSliceIndices = [
+        Math.floor((ranges[0].end - ranges[0].start) / 2), // Middle of Aufschnitte
+        Math.floor((ranges[1].end - ranges[1].start) / 2), // Middle of Seitenansichten
+        Math.floor((ranges[2].end - ranges[2].start) / 2), // Middle of Querschnitte
+      ];
 
-      const keepSlices = new Set([initialSlice]);
+      // Start with the three middle slices
+      const initialSlices = [
+        this.availableSlices[ranges[0].start + this.currentSliceIndices[0]],
+        this.availableSlices[ranges[1].start + this.currentSliceIndices[1]],
+        this.availableSlices[ranges[2].start + this.currentSliceIndices[2]],
+      ].filter((s) => s !== undefined);
+
+      const keepSlices = new Set(initialSlices);
       const prunedTileset = makePrunedTileset(
         tilesetJson,
         keepSlices,
         resource.url,
       );
       tilesetUrl = toBlobUrl(prunedTileset);
+      this.currentBlobUrl = tilesetUrl;
     } else {
       // For other sources, use the resource URL directly
       tilesetUrl = resource.url;
@@ -324,6 +406,12 @@ export class Tiles3dLayerController extends BaseLayerController<Tiles3dLayer> {
       tileset.destroy();
     }
     this._tileset = undefined as unknown as Cesium3DTileset;
+
+    // Release blob URL if it exists
+    if (this.currentBlobUrl) {
+      URL.revokeObjectURL(this.currentBlobUrl);
+      this.currentBlobUrl = null;
+    }
 
     this.scenePickingLock?.release();
     this.scenePickingLock = null;

--- a/ui/src/features/layer/controllers/layer-tiles3d.controller.ts
+++ b/ui/src/features/layer/controllers/layer-tiles3d.controller.ts
@@ -19,6 +19,8 @@ export class Tiles3dLayerController extends BaseLayerController<Tiles3dLayer> {
   private _tileset!: Cesium3DTileset;
 
   private scenePickingLock: ScenePickingLock | null = null;
+  private originalTilesetJson: any = null;
+  private baseUrl: string = '';
 
   get type(): LayerType.Tiles3d {
     return LayerType.Tiles3d;
@@ -34,6 +36,93 @@ export class Tiles3dLayerController extends BaseLayerController<Tiles3dLayer> {
 
   moveToTop(): void {
     this.viewer.scene.primitives.raiseToTop(this.tileset);
+  }
+
+  /**
+   * Update the displayed slices for OGC tileset sources.
+   * @param sliceNumbers - Array of slice numbers to display (e.g., [227, 245, 348])
+   */
+  async updateSlices(sliceNumbers: number[]): Promise<void> {
+    if (this.layer.source.type !== 'Ogc') {
+      console.warn('updateSlices is only supported for OGC sources');
+      return;
+    }
+
+    if (!this.originalTilesetJson || !this.baseUrl) {
+      console.error('Original tileset JSON or base URL not available');
+      return;
+    }
+
+    // Create pruned tileset with new slices
+    const keepSlices = new Set(sliceNumbers);
+    const prunedTileset = makePrunedTileset(
+      this.originalTilesetJson,
+      keepSlices,
+      this.baseUrl,
+    );
+    const tilesetUrl = toBlobUrl(prunedTileset);
+
+    // Store current state
+    const currentOpacity = this.layer.opacity;
+    const currentVisibility = this.layer.isVisible;
+    const currentIndex = this.findIndexInPrimitives(this.tileset);
+
+    // Remove old tileset
+    this.viewer.scene.primitives.remove(this.tileset);
+    if (!this.tileset.isDestroyed()) {
+      this.tileset.destroy();
+    }
+
+    // Create new tileset with updated slices
+    const tileset = await Cesium3DTileset.fromUrl(tilesetUrl, {
+      show: currentVisibility,
+      backFaceCulling: false,
+      enableCollision: true,
+
+      maximumScreenSpaceError: 16,
+      cullWithChildrenBounds: true,
+      cullRequestsWhileMoving: true,
+      cullRequestsWhileMovingMultiplier: 100,
+      preloadWhenHidden: false,
+      preferLeaves: true,
+      dynamicScreenSpaceError: true,
+      foveatedScreenSpaceError: true,
+      foveatedConeSize: 0.2,
+      foveatedMinimumScreenSpaceErrorRelaxation: 3,
+      foveatedTimeDelay: 0.2,
+    });
+
+    tileset.imageBasedLighting = new ImageBasedLighting();
+    tileset.imageBasedLighting.imageBasedLightingFactor = new Cartesian2(1, 0);
+    tileset.customShader = this.makeShader();
+
+    // Add at the same position as before
+    if (currentIndex !== null) {
+      this.viewer.scene.primitives.add(tileset, currentIndex);
+    } else {
+      this.viewer.scene.primitives.add(tileset);
+    }
+
+    this._tileset = tileset;
+
+    // Restore opacity if it was different from 1
+    if (currentOpacity !== 1) {
+      tileset.customShader?.setUniform('u_alpha', currentOpacity);
+    }
+
+    // Set up load progress tracking
+    const pickService = PickService.get();
+    this.scenePickingLock = pickService.acquireScenePickingLock();
+    tileset.loadProgress.addEventListener(
+      (numberOfPendingRequests: number, numberOfTilesProcessing: number) => {
+        if (numberOfPendingRequests === 0 && numberOfTilesProcessing === 0) {
+          this.scenePickingLock?.release();
+          this.scenePickingLock = null;
+        } else {
+          this.scenePickingLock ??= pickService.acquireScenePickingLock();
+        }
+      },
+    );
   }
 
   protected reactToChanges(): void {
@@ -71,7 +160,10 @@ export class Tiles3dLayerController extends BaseLayerController<Tiles3dLayer> {
       };
       // For OGC sources, fetch the tileset JSON, prune it, and create a blob URL
       const tilesetJson = await resource.fetchJson();
-      const keepSlices = new Set([227, 245, 348]);
+      this.originalTilesetJson = tilesetJson;
+      this.baseUrl = resource.url;
+
+      const keepSlices = new Set([1000]);
       const prunedTileset = makePrunedTileset(
         tilesetJson,
         keepSlices,

--- a/ui/src/features/layer/controllers/layer-tiles3d.controller.ts
+++ b/ui/src/features/layer/controllers/layer-tiles3d.controller.ts
@@ -15,6 +15,23 @@ import {
 import { OBJECT_HIGHLIGHT_NORMALIZED_RGB } from 'src/constants';
 import { PickService, ScenePickingLock } from 'src/services/pick.service';
 
+export type SliceIndices = {
+  inline: number;
+  crossline: number;
+  depth: number;
+};
+
+export type SliceRange = {
+  start: number;
+  end: number;
+};
+
+export type SliceRanges = {
+  inline: SliceRange;
+  crossline: SliceRange;
+  depth: SliceRange;
+};
+
 export class Tiles3dLayerController extends BaseLayerController<Tiles3dLayer> {
   private _tileset!: Cesium3DTileset;
 
@@ -22,10 +39,13 @@ export class Tiles3dLayerController extends BaseLayerController<Tiles3dLayer> {
   private originalTilesetJson: any = null;
   private baseUrl: string = '';
   private availableSlices: number[] = [];
-  private currentBlobUrl: string | null = null;
   private isUpdatingSlices: boolean = false;
   private pendingSliceUpdate: number[] | null = null;
-  private currentSliceIndices: [number, number, number] = [0, 0, 0]; // Indices for the three sliders
+  private currentSliceIndices: SliceIndices = {
+    inline: 0,
+    crossline: 0,
+    depth: 0,
+  };
 
   get type(): LayerType.Tiles3d {
     return LayerType.Tiles3d;
@@ -44,49 +64,49 @@ export class Tiles3dLayerController extends BaseLayerController<Tiles3dLayer> {
 
   /**
    * Get the slice ranges for the three categories.
-   * Returns [aufschnitte, seitenansichten, querschnitte] ranges.
+   * Returns ranges for inline (aufschnitte), crossline (seitenansichten), and depth (querschnitte).
    * Will be removed once we get the ranges from the backend
    */
-  getSliceRanges(): [
-    { start: number; end: number },
-    { start: number; end: number },
-    { start: number; end: number },
-  ] {
+  getSliceRanges(): SliceRanges {
     const total = this.availableSlices.length;
     const third = Math.floor(total / 3);
 
-    return [
-      { start: 0, end: third - 1 },
-      { start: third, end: 2 * third - 1 },
-      { start: 2 * third, end: total - 1 },
-    ];
+    return {
+      inline: { start: 0, end: third - 1 },
+      crossline: { start: third, end: 2 * third - 1 },
+      depth: { start: 2 * third, end: total - 1 },
+    };
   }
 
   /**
    * Get current slice indices for the three sliders.
    */
-  getCurrentSliceIndices(): [number, number, number] {
+  getCurrentSliceIndices(): SliceIndices {
     return this.currentSliceIndices;
   }
 
   /**
    * Update a specific slider's slice index.
-   * @param sliderIndex - 0 for Aufschnitte, 1 for Seitenansichten, 2 for Querschnitte
+   * @param key - The slice key to update ('inline', 'crossline', or 'depth')
    * @param index - The new index value
    */
   async updateSliceAtIndex(
-    sliderIndex: 0 | 1 | 2,
+    key: keyof SliceIndices,
     index: number,
   ): Promise<void> {
-    this.currentSliceIndices[sliderIndex] = index;
+    this.currentSliceIndices = {
+      ...this.currentSliceIndices,
+      [key]: index,
+    };
 
     // Get all three slice numbers
     const ranges = this.getSliceRanges();
     const sliceNumbers: number[] = [];
 
-    for (let i = 0; i < 3; i++) {
-      const range = ranges[i];
-      const localIndex = this.currentSliceIndices[i];
+    const keys: (keyof SliceIndices)[] = ['inline', 'crossline', 'depth'];
+    keys.forEach((k) => {
+      const range = ranges[k];
+      const localIndex = this.currentSliceIndices[k];
       const globalIndex = range.start + localIndex;
 
       if (
@@ -97,7 +117,7 @@ export class Tiles3dLayerController extends BaseLayerController<Tiles3dLayer> {
       ) {
         sliceNumbers.push(this.availableSlices[globalIndex]);
       }
-    }
+    });
 
     await this.updateSlices(sliceNumbers);
   }
@@ -106,7 +126,9 @@ export class Tiles3dLayerController extends BaseLayerController<Tiles3dLayer> {
    * Check if this layer supports slice selection.
    */
   get supportsSliceSelection(): boolean {
-    return this.layer.source.type === 'Ogc' && this.availableSlices.length > 0;
+    return (
+      this.layer.id === 'seismic_3d_E11' && this.availableSlices.length > 0
+    );
   }
 
   zoomIntoView(): void {
@@ -121,9 +143,11 @@ export class Tiles3dLayerController extends BaseLayerController<Tiles3dLayer> {
    * Update the displayed slices for OGC tileset sources.
    * @param sliceNumbers - Array of slice numbers to display (e.g., [227, 245, 348])
    */
+
   async updateSlices(sliceNumbers: number[]): Promise<void> {
-    if (this.layer.source.type !== 'Ogc') {
-      console.warn('updateSlices is only supported for OGC sources');
+    // TODO - This condition will have to be adapted as currenlty only one layer supports slicers
+    if (this.layer.id !== 'seismic_3d_E11') {
+      console.warn('updateSlices is only supported for seismic_3d_E11');
       return;
     }
 
@@ -182,15 +206,6 @@ export class Tiles3dLayerController extends BaseLayerController<Tiles3dLayer> {
         this.tileset.destroy();
       }
     }
-
-    // Release old blob URL
-    if (this.currentBlobUrl) {
-      URL.revokeObjectURL(this.currentBlobUrl);
-      this.currentBlobUrl = null;
-    }
-
-    // Store new blob URL
-    this.currentBlobUrl = tilesetUrl;
 
     // Create new tileset with updated slices
     const tileset = await Cesium3DTileset.fromUrl(tilesetUrl, {
@@ -299,7 +314,8 @@ export class Tiles3dLayerController extends BaseLayerController<Tiles3dLayer> {
     const resource = await mapLayerSourceToResource(this.layer.source);
     let tilesetUrl: string;
 
-    if (this.layer.source.type === 'Ogc') {
+    // TODO - This condition will have to be adapted as currenlty only one layer supports slicers
+    if (this.layer.id === 'seismic_3d_E11') {
       const token = import.meta.env['VITE_OGC_GST_BASIC_AUTH'];
       const originalFetch = Resource.prototype.fetch;
       Resource.prototype.fetch = function (options) {
@@ -309,27 +325,31 @@ export class Tiles3dLayerController extends BaseLayerController<Tiles3dLayer> {
         };
         return originalFetch.call(this, options);
       };
-      // For OGC sources, fetch the tileset JSON, prune it, and create a blob URL
       const tilesetJson = await resource.fetchJson();
       this.originalTilesetJson = tilesetJson;
       this.baseUrl = resource.url;
 
-      // Extract all available slices
       this.availableSlices = this.extractAvailableSlices(tilesetJson);
 
-      // Initialize the three sliders to their middle positions
       const ranges = this.getSliceRanges();
-      this.currentSliceIndices = [
-        Math.floor((ranges[0].end - ranges[0].start) / 2), // Middle of Aufschnitte
-        Math.floor((ranges[1].end - ranges[1].start) / 2), // Middle of Seitenansichten
-        Math.floor((ranges[2].end - ranges[2].start) / 2), // Middle of Querschnitte
-      ];
+      this.currentSliceIndices = {
+        inline: Math.floor((ranges.inline.end - ranges.inline.start) / 2),
+        crossline: Math.floor(
+          (ranges.crossline.end - ranges.crossline.start) / 2,
+        ),
+        depth: Math.floor((ranges.depth.end - ranges.depth.start) / 2),
+      };
 
-      // Start with the three middle slices
       const initialSlices = [
-        this.availableSlices[ranges[0].start + this.currentSliceIndices[0]],
-        this.availableSlices[ranges[1].start + this.currentSliceIndices[1]],
-        this.availableSlices[ranges[2].start + this.currentSliceIndices[2]],
+        this.availableSlices[
+          ranges.inline.start + this.currentSliceIndices.inline
+        ],
+        this.availableSlices[
+          ranges.crossline.start + this.currentSliceIndices.crossline
+        ],
+        this.availableSlices[
+          ranges.depth.start + this.currentSliceIndices.depth
+        ],
       ].filter((s) => s !== undefined);
 
       const keepSlices = new Set(initialSlices);
@@ -339,7 +359,6 @@ export class Tiles3dLayerController extends BaseLayerController<Tiles3dLayer> {
         resource.url,
       );
       tilesetUrl = toBlobUrl(prunedTileset);
-      this.currentBlobUrl = tilesetUrl;
     } else {
       // For other sources, use the resource URL directly
       tilesetUrl = resource.url;
@@ -406,12 +425,6 @@ export class Tiles3dLayerController extends BaseLayerController<Tiles3dLayer> {
       tileset.destroy();
     }
     this._tileset = undefined as unknown as Cesium3DTileset;
-
-    // Release blob URL if it exists
-    if (this.currentBlobUrl) {
-      URL.revokeObjectURL(this.currentBlobUrl);
-      this.currentBlobUrl = null;
-    }
 
     this.scenePickingLock?.release();
     this.scenePickingLock = null;


### PR DESCRIPTION
POC für den 3D Tiles Slider. 
Aktuell sind die 3 Slider hardcodiert für jeweils einen Drittel der Slices zuständing, muss angepasst werden sobald klar ist, woher die Information kommt, welche Slices crossline, inline oder depth sind. 

Die gesamte Logik der Slider kann auch noch extrahiert werden aus dem layer-tiles3d.controller, da sie (aktuell) nur für einen Layer verwendet wird. Somit könnte der Controller sauberer gehalten werden. 