### PR TITLE
Fix cypress: Specify gl settings explicitly

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -404,14 +404,14 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y \
-            libegl1 \
-            libegl1-mesa \
-            libgl1-mesa-dri \
-            libgles2 \
+            xvfb \
             libgbm1 \
-            libvulkan1 \
-            mesa-vulkan-drivers \
-            xvfb
+            mesa-utils \
+            libnss3 \
+            libatk-bridge2.0-0 \
+            libxkbcommon0 \
+            libgtk-3-0
+
       - name: Restore cargo registry
         uses: actions/cache/restore@v4
         with:

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -456,7 +456,7 @@ jobs:
         with:
           command: |
             npm run cypress:run -- \
-              --browser edge \
+              --browser chrome \
               --record \
               --key ${{ secrets.CYPRESS_RECORD_KEY }}
           install: false

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -394,6 +394,24 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@1.90
+      - name: Install Mesa libraries for headless WebGL
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libegl1 \
+            libegl1-mesa \
+            libgl1-mesa-dri \
+            libgles2 \
+            libgbm1 \
+            libvulkan1 \
+            mesa-vulkan-drivers \
+            xvfb
       - name: Restore cargo registry
         uses: actions/cache/restore@v4
         with:
@@ -455,10 +473,11 @@ jobs:
         uses: cypress-io/github-action@v6
         with:
           command: |
-            npm run cypress:run -- \
-              --browser chrome \
-              --record \
-              --key ${{ secrets.CYPRESS_RECORD_KEY }}
+            xvfb-run --auto-servernum --server-args="-screen 0 1920x1280x24" \
+              npm run cypress:run -- \
+                --browser chrome \
+                --record \
+                --key ${{ secrets.CYPRESS_RECORD_KEY }}
           install: false
           wait-on: "http://localhost:8000"
           wait-on-timeout: 120

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -458,7 +458,7 @@ jobs:
             npm run cypress:run -- \
               --browser edge \
               --record \
-              --key ${{ secrets.CYPRESS_RECORD_KEY }} \
+              --key ${{ secrets.CYPRESS_RECORD_KEY }}
           install: false
           wait-on: "http://localhost:8000"
           wait-on-timeout: 120

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -469,15 +469,18 @@ jobs:
           echo $! > ../ui.pid
           chmod +x ../.github/scripts/wait_for_port.sh
           ../.github/scripts/wait_for_port.sh localhost 8000
+      - name: Start Xvfb
+        run: |
+          Xvfb :99 -screen 0 1920x1280x24 &
+          echo "DISPLAY=:99" >> $GITHUB_ENV
       - name: Cypress run
         uses: cypress-io/github-action@v6
         with:
           command: |
-            xvfb-run --auto-servernum --server-args="-screen 0 1920x1280x24" \
-              npm run cypress:run -- \
-                --browser chrome \
-                --record \
-                --key ${{ secrets.CYPRESS_RECORD_KEY }}
+            npm run cypress:run -- \
+              --browser chrome \
+              --record \
+              --key ${{ secrets.CYPRESS_RECORD_KEY }}
           install: false
           wait-on: "http://localhost:8000"
           wait-on-timeout: 120

--- a/ui/cypress/cypress.config.ts
+++ b/ui/cypress/cypress.config.ts
@@ -27,14 +27,18 @@ const setupNodeEvents = async (
   );
   config.env.TAGS = 'not @skip';
 
-  // Stabilize WebGL in GitHub Actions / headless Linux for Cesium
+  // Stabilize WebGL in headless / GPU-less environments for Cesium.
+  // Chrome 121+ blocks SwiftShader-WebGL by default; --enable-unsafe-swiftshader re-enables it.
+  // --use-angle=swiftshader-webgl replaces the deprecated --use-gl=swiftshader.
   on('before:browser:launch', (browser, launchOptions) => {
-    if (!process.env.CI) return launchOptions;
-
-    // Only affects Chromium-family browsers (Edge/Chrome). Electron uses ELECTRON_EXTRA_LAUNCH_ARGS.
     if (browser.family === 'chromium') {
-      launchOptions.args.push('--use-gl=swiftshader');
+      launchOptions.args.push('--use-angle=swiftshader-webgl');
+      launchOptions.args.push('--enable-unsafe-swiftshader');
+      launchOptions.args.push('--disable-gpu');
       launchOptions.args.push('--disable-dev-shm-usage');
+      launchOptions.args.push('--ignore-gpu-blocklist');
+      launchOptions.args.push('--enable-webgl');
+      launchOptions.args.push('--disable-gpu-sandbox');
     }
 
     return launchOptions;

--- a/ui/cypress/cypress.config.ts
+++ b/ui/cypress/cypress.config.ts
@@ -26,6 +26,20 @@ const setupNodeEvents = async (
     }),
   );
   config.env.TAGS = 'not @skip';
+
+  // Stabilize WebGL in GitHub Actions / headless Linux for Cesium
+  on('before:browser:launch', (browser, launchOptions) => {
+    if (!process.env.CI) return launchOptions;
+
+    // Only affects Chromium-family browsers (Edge/Chrome). Electron uses ELECTRON_EXTRA_LAUNCH_ARGS.
+    if (browser.family === 'chromium') {
+      launchOptions.args.push('--use-gl=swiftshader');
+      launchOptions.args.push('--disable-dev-shm-usage');
+    }
+
+    return launchOptions;
+  });
+
   return config;
 };
 

--- a/ui/cypress/support/e2e.ts
+++ b/ui/cypress/support/e2e.ts
@@ -1,5 +1,19 @@
 import 'cypress-real-events';
 
+// Prevent Cesium's WebGL initialization errors from failing tests.
+// In headless / GPU-less environments the browser may support WebGL in theory
+// but fail to create a context, causing an unhandled promise rejection in
+// CesiumWidget / Viewer.
+Cypress.on('uncaught:exception', (err) => {
+  if (
+    err.message.includes('WebGL') ||
+    err.message.includes('initialization failed')
+  ) {
+    return false; // suppress the error and let the test continue
+  }
+  // Let other errors fail the test as usual
+});
+
 beforeEach(() => {
   cy.intercept('GET', 'https://**.cesium.com/**', { log: false });
   cy.intercept('GET', 'https://**.geo.admin.ch/**', { log: false });


### PR DESCRIPTION
resolves [#867 ](https://github.com/swisstopo/swissgeol-assets-suite/issues/867)

In february, the github action runners switched from ubuntu 22 to 24. Apparently there are major changes relating to 3D graphics - which is why we have to manually install some packages and enforce X11 so that cesium can use webgl.