### PR TITLE
Use recreate strategy for abbreviator

### DIFF
--- a/k8s/templates/deployment.abbreviator.yaml
+++ b/k8s/templates/deployment.abbreviator.yaml
@@ -9,6 +9,8 @@ metadata:
     keel.sh/trigger: poll
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: {{ .Release.Name }}-abbreviator


### PR DESCRIPTION
resolves #1910 
Use recreate strategy for abbreviator, so that the in use volume does… not block the start of the new pod.