### PR TITLE
#1951: adjustment - infobox item order defineable

### DIFF
--- a/api/src/layers/mod.rs
+++ b/api/src/layers/mod.rs
@@ -107,37 +107,12 @@ pub enum InfoBox {
         ///   - a `{ key, url }` object, rendered as a link whose label is translated from `key`. The url can be:
         ///      - a URL string (starting with `http://` or `https://`)
         ///      - a plain string used as a translation key to resolve a localized url.
-        #[serde(default, skip_serializing_if = "InformationEntries::is_empty")]
-        information: InformationEntries,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        information: Vec<InformationEntry>,
     },
 }
 
 /// Information entries displayed in the info box.
-///
-/// Supported config formats:
-/// - ordered list: `[{ key, value }, ...]`
-/// - legacy object: `{ key1: value1, key2: value2, ... }`
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(untagged)]
-pub enum InformationEntries {
-    Ordered(Vec<InformationEntry>),
-    Legacy(HashMap<String, InformationValue>),
-}
-
-impl Default for InformationEntries {
-    fn default() -> Self {
-        Self::Ordered(vec![])
-    }
-}
-
-impl InformationEntries {
-    fn is_empty(&self) -> bool {
-        match self {
-            Self::Ordered(entries) => entries.is_empty(),
-            Self::Legacy(entries) => entries.is_empty(),
-        }
-    }
-}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct InformationEntry {

--- a/api/src/layers/mod.rs
+++ b/api/src/layers/mod.rs
@@ -101,8 +101,8 @@ pub enum InfoBox {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         legend_url: Option<String>,
 
-        /// Key-value pairs displayed in the info box.
-        /// The key is a translation key for the label; the value is one of:
+        /// Ordered entries displayed in the info box.
+        /// `label_key` is a translation key for the row label; `value` is one of:
         ///   - a plain string.
         ///   - a `{ key, url }` object, rendered as a link whose label is translated from `key`. The url can be:
         ///      - a URL string (starting with `http://` or `https://`)
@@ -115,8 +115,10 @@ pub enum InfoBox {
 /// Information entries displayed in the info box.
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all(serialize = "camelCase", deserialize = "snake_case"))]
 pub struct InformationEntry {
-    pub key: String,
+    #[serde(alias = "key")]
+    pub label_key: String,
     pub value: InformationValue,
 }
 

--- a/api/src/layers/mod.rs
+++ b/api/src/layers/mod.rs
@@ -107,9 +107,42 @@ pub enum InfoBox {
         ///   - a `{ key, url }` object, rendered as a link whose label is translated from `key`. The url can be:
         ///      - a URL string (starting with `http://` or `https://`)
         ///      - a plain string used as a translation key to resolve a localized url.
-        #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-        information: HashMap<String, InformationValue>,
+        #[serde(default, skip_serializing_if = "InformationEntries::is_empty")]
+        information: InformationEntries,
     },
+}
+
+/// Information entries displayed in the info box.
+///
+/// Supported config formats:
+/// - ordered list: `[{ key, value }, ...]`
+/// - legacy object: `{ key1: value1, key2: value2, ... }`
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum InformationEntries {
+    Ordered(Vec<InformationEntry>),
+    Legacy(HashMap<String, InformationValue>),
+}
+
+impl Default for InformationEntries {
+    fn default() -> Self {
+        Self::Ordered(vec![])
+    }
+}
+
+impl InformationEntries {
+    fn is_empty(&self) -> bool {
+        match self {
+            Self::Ordered(entries) => entries.is_empty(),
+            Self::Legacy(entries) => entries.is_empty(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InformationEntry {
+    pub key: String,
+    pub value: InformationValue,
 }
 
 /// A value in the info box's information table.

--- a/docs/layer-config/shared-layer-config.md
+++ b/docs/layer-config/shared-layer-config.md
@@ -46,8 +46,7 @@ independent of their layer type.
   // - `api3.geo.admin.ch`: The legend is fetched as HTML from api3.geo.admin.ch via the layer's id.
   // - `custom`: Displays translated info text (key: `layers:infoBox.{layerId}`),
   //   an optional URL, and optional `information` entries.
-  //   Preferred format is an ordered array of `{ key, value }` entries.
-  //   Legacy object-map format is still supported for backward compatibility.
+  //   `information` is an ordered array of `{ key, value }` entries.
   //   The information `value` can be:
   //   - a plain string.
   //   - a `{ key, url }` object, rendered as a link whose label is translated from `key`. The url can be:
@@ -56,7 +55,7 @@ independent of their layer type.
   //
   // If left out, no info box will be available for the layer.
   //
-  // @type { source: 'api3.geo.admin.ch' } | { source: 'custom', legend_url?: string, information?: Array<{ key: string, value: string | { key: string, url: string } }> | { [key: string]: string | { key: string, url: string } } } | null
+  // @type { source: 'api3.geo.admin.ch' } | { source: 'custom', legend_url?: string, information?: Array<{ key: string, value: string | { key: string, url: string } }> } | null
   // @default null
   info_box: null,
 

--- a/docs/layer-config/shared-layer-config.md
+++ b/docs/layer-config/shared-layer-config.md
@@ -46,7 +46,7 @@ independent of their layer type.
   // - `api3.geo.admin.ch`: The legend is fetched as HTML from api3.geo.admin.ch via the layer's id.
   // - `custom`: Displays translated info text (key: `layers:infoBox.{layerId}`),
   //   an optional URL, and optional `information` entries.
-  //   `information` is an ordered array of `{ key, value }` entries.
+  //   `information` is an ordered array of `{ label_key, value }` entries.
   //   The information `value` can be:
   //   - a plain string.
   //   - a `{ key, url }` object, rendered as a link whose label is translated from `key`. The url can be:
@@ -55,7 +55,7 @@ independent of their layer type.
   //
   // If left out, no info box will be available for the layer.
   //
-  // @type { source: 'api3.geo.admin.ch' } | { source: 'custom', legend_url?: string, information?: Array<{ key: string, value: string | { key: string, url: string } }> } | null
+  // @type { source: 'api3.geo.admin.ch' } | { source: 'custom', legend_url?: string, information?: Array<{ label_key: string, value: string | { key: string, url: string } }> } | null
   // @default null
   info_box: null,
 

--- a/docs/layer-config/shared-layer-config.md
+++ b/docs/layer-config/shared-layer-config.md
@@ -45,8 +45,10 @@ independent of their layer type.
   // Two modes are supported:
   // - `api3.geo.admin.ch`: The legend is fetched as HTML from api3.geo.admin.ch via the layer's id.
   // - `custom`: Displays translated info text (key: `layers:infoBox.{layerId}`),
-  //   an optional URL, and optional key-value `information` pairs.
-  //   The information value can be:
+  //   an optional URL, and optional `information` entries.
+  //   Preferred format is an ordered array of `{ key, value }` entries.
+  //   Legacy object-map format is still supported for backward compatibility.
+  //   The information `value` can be:
   //   - a plain string.
   //   - a `{ key, url }` object, rendered as a link whose label is translated from `key`. The url can be:
   //      - a URL string (starting with `http://` or `https://`)
@@ -54,7 +56,7 @@ independent of their layer type.
   //
   // If left out, no info box will be available for the layer.
   //
-  // @type { source: 'api3.geo.admin.ch' } | { source: 'custom', legend_url?: string, information?: { [key: string]: string | { key: string, url: string } } } | null
+  // @type { source: 'api3.geo.admin.ch' } | { source: 'custom', legend_url?: string, information?: Array<{ key: string, value: string | { key: string, url: string } }> | { [key: string]: string | { key: string, url: string } } } | null
   // @default null
   info_box: null,
 

--- a/layers/layers_3dtiles.json5
+++ b/layers/layers_3dtiles.json5
@@ -1031,14 +1031,20 @@
       //geocat_id: '',
       info_box: {
         source: 'custom',
-        information: {
-          contact: { key: 'contact_value', url: 'contact_url' },
-          description_sa3d_HL_profiles_01: {
-            key: 'description_value_sa3d_HL_profiles_01',
-            url: 'description_url_sa3d_HL_profiles_01',
+        information: [
+          {
+            key: 'contact',
+            value: { key: 'contact_value', url: 'contact_url' },
           },
-          dataDate: '28.04.2026',
-        },
+          {
+            key: 'description_sa3d_HL_profiles_01',
+            value: {
+              key: 'description_value_sa3d_HL_profiles_01',
+              url: 'description_url_sa3d_HL_profiles_01',
+            },
+          },
+          { key: 'dataDate', value: '28.04.2026' },
+        ],
       },
     },
     // HL - Faults
@@ -1054,14 +1060,20 @@
       //geocat_id: '',
       info_box: {
         source: 'custom',
-        information: {
-          contact: { key: 'contact_value', url: 'contact_url' },
-          description_sa3d_HL_profiles_01: {
-            key: 'description_value_sa3d_HL_profiles_01',
-            url: 'description_url_sa3d_HL_profiles_01',
+        information: [
+          {
+            key: 'contact',
+            value: { key: 'contact_value', url: 'contact_url' },
           },
-          dataDate: '28.04.2026',
-        },
+          {
+            key: 'description_sa3d_HL_profiles_01',
+            value: {
+              key: 'description_value_sa3d_HL_profiles_01',
+              url: 'description_url_sa3d_HL_profiles_01',
+            },
+          },
+          { key: 'dataDate', value: '28.04.2026' },
+        ],
       },
     },
     // HL - Horizons - Nappe
@@ -1076,14 +1088,20 @@
       //geocat_id: '',
       info_box: {
         source: 'custom',
-        information: {
-          contact: { key: 'contact_value', url: 'contact_url' },
-          description_sa3d_HL_profiles_01: {
-            key: 'description_value_sa3d_HL_profiles_01',
-            url: 'description_url_sa3d_HL_profiles_01',
+        information: [
+          {
+            key: 'contact',
+            value: { key: 'contact_value', url: 'contact_url' },
           },
-          dataDate: '28.04.2026',
-        },
+          {
+            key: 'description_sa3d_HL_profiles_01',
+            value: {
+              key: 'description_value_sa3d_HL_profiles_01',
+              url: 'description_url_sa3d_HL_profiles_01',
+            },
+          },
+          { key: 'dataDate', value: '28.04.2026' },
+        ],
       },
     },
     // HL - Horizons - Mesozoic sediments
@@ -1099,14 +1117,20 @@
       //geocat_id: '',
       info_box: {
         source: 'custom',
-        information: {
-          contact: { key: 'contact_value', url: 'contact_url' },
-          description_sa3d_HL_profiles_01: {
-            key: 'description_value_sa3d_HL_profiles_01',
-            url: 'description_url_sa3d_HL_profiles_01',
+        information: [
+          {
+            key: 'contact',
+            value: { key: 'contact_value', url: 'contact_url' },
           },
-          dataDate: '28.04.2026',
-        },
+          {
+            key: 'description_sa3d_HL_profiles_01',
+            value: {
+              key: 'description_value_sa3d_HL_profiles_01',
+              url: 'description_url_sa3d_HL_profiles_01',
+            },
+          },
+          { key: 'dataDate', value: '28.04.2026' },
+        ],
       },
     },
     // HL - Horizons - Cristalline basement
@@ -1121,14 +1145,20 @@
       //geocat_id: '',
       info_box: {
         source: 'custom',
-        information: {
-          contact: { key: 'contact_value', url: 'contact_url' },
-          description_sa3d_HL_profiles_01: {
-            key: 'description_value_sa3d_HL_profiles_01',
-            url: 'description_url_sa3d_HL_profiles_01',
+        information: [
+          {
+            key: 'contact',
+            value: { key: 'contact_value', url: 'contact_url' },
           },
-          dataDate: '28.04.2026',
-        },
+          {
+            key: 'description_sa3d_HL_profiles_01',
+            value: {
+              key: 'description_value_sa3d_HL_profiles_01',
+              url: 'description_url_sa3d_HL_profiles_01',
+            },
+          },
+          { key: 'dataDate', value: '28.04.2026' },
+        ],
       },
     },
     // =================================================================
@@ -1144,14 +1174,20 @@
       //geocat_id: '',
       info_box: {
         source: 'custom',
-        information: {
-          contact: { key: 'contact_value', url: 'contact_url' },
-          description_sa3d_PR_profiles_01: {
-            key: 'description_value_sa3d_PR_profiles_01',
-            url: 'description_url_sa3d_PR_profiles_01',
+        information: [
+          {
+            key: 'contact',
+            value: { key: 'contact_value', url: 'contact_url' },
           },
-          dataDate: '28.04.2026',
-        },
+          {
+            key: 'description_sa3d_PR_profiles_01',
+            value: {
+              key: 'description_value_sa3d_PR_profiles_01',
+              url: 'description_url_sa3d_PR_profiles_01',
+            },
+          },
+          { key: 'dataDate', value: '28.04.2026' },
+        ],
       },
     },
     // PR - Faults
@@ -1167,14 +1203,20 @@
       //geocat_id: '',
       info_box: {
         source: 'custom',
-        information: {
-          contact: { key: 'contact_value', url: 'contact_url' },
-          description_sa3d_PR_profiles_01: {
-            key: 'description_value_sa3d_PR_profiles_01',
-            url: 'description_url_sa3d_PR_profiles_01',
+        information: [
+          {
+            key: 'contact',
+            value: { key: 'contact_value', url: 'contact_url' },
           },
-          dataDate: '28.04.2026',
-        },
+          {
+            key: 'description_sa3d_PR_profiles_01',
+            value: {
+              key: 'description_value_sa3d_PR_profiles_01',
+              url: 'description_url_sa3d_PR_profiles_01',
+            },
+          },
+          { key: 'dataDate', value: '28.04.2026' },
+        ],
       },
     },
     // PR - Horizons
@@ -1189,14 +1231,20 @@
       //geocat_id: '',
       info_box: {
         source: 'custom',
-        information: {
-          contact: { key: 'contact_value', url: 'contact_url' },
-          description_sa3d_PR_profiles_01: {
-            key: 'description_value_sa3d_PR_profiles_01',
-            url: 'description_url_sa3d_PR_profiles_01',
+        information: [
+          {
+            key: 'contact',
+            value: { key: 'contact_value', url: 'contact_url' },
           },
-          dataDate: '28.04.2026',
-        },
+          {
+            key: 'description_sa3d_PR_profiles_01',
+            value: {
+              key: 'description_value_sa3d_PR_profiles_01',
+              url: 'description_url_sa3d_PR_profiles_01',
+            },
+          },
+          { key: 'dataDate', value: '28.04.2026' },
+        ],
       },
     },
     // =================================================================
@@ -1212,14 +1260,20 @@
       //geocat_id: '',
       info_box: {
         source: 'custom',
-        information: {
-          contact: { key: 'contact_value', url: 'contact_url' },
-          description_sa3d_SAM_profiles_01: {
-            key: 'description_value_sa3d_SAM_profiles_01',
-            url: 'description_url_sa3d_SAM_profiles_01',
+        information: [
+          {
+            key: 'contact',
+            value: { key: 'contact_value', url: 'contact_url' },
           },
-          dataDate: '28.04.2026',
-        },
+          {
+            key: 'description_sa3d_SAM_profiles_01',
+            value: {
+              key: 'description_value_sa3d_SAM_profiles_01',
+              url: 'description_url_sa3d_SAM_profiles_01',
+            },
+          },
+          { key: 'dataDate', value: '28.04.2026' },
+        ],
       },
     },
     // SAM - Faults
@@ -1235,14 +1289,20 @@
       //geocat_id: '',
       info_box: {
         source: 'custom',
-        information: {
-          contact: { key: 'contact_value', url: 'contact_url' },
-          description_sa3d_SAM_profiles_01: {
-            key: 'description_value_sa3d_SAM_profiles_01',
-            url: 'description_url_sa3d_SAM_profiles_01',
+        information: [
+          {
+            key: 'contact',
+            value: { key: 'contact_value', url: 'contact_url' },
           },
-          dataDate: '28.04.2026',
-        },
+          {
+            key: 'description_sa3d_SAM_profiles_01',
+            value: {
+              key: 'description_value_sa3d_SAM_profiles_01',
+              url: 'description_url_sa3d_SAM_profiles_01',
+            },
+          },
+          { key: 'dataDate', value: '28.04.2026' },
+        ],
       },
     },
     // SAM - Thrust Faults
@@ -1257,14 +1317,20 @@
       //geocat_id: '',
       info_box: {
         source: 'custom',
-        information: {
-          contact: { key: 'contact_value', url: 'contact_url' },
-          description_sa3d_SAM_profiles_01: {
-            key: 'description_value_sa3d_SAM_profiles_01',
-            url: 'description_url_sa3d_SAM_profiles_01',
+        information: [
+          {
+            key: 'contact',
+            value: { key: 'contact_value', url: 'contact_url' },
           },
-          dataDate: '28.04.2026',
-        },
+          {
+            key: 'description_sa3d_SAM_profiles_01',
+            value: {
+              key: 'description_value_sa3d_SAM_profiles_01',
+              url: 'description_url_sa3d_SAM_profiles_01',
+            },
+          },
+          { key: 'dataDate', value: '28.04.2026' },
+        ],
       },
     },
     // =================================================================
@@ -1290,12 +1356,15 @@
       //geocat_id: '752146b4-7fd4-4621-8cf8-fdb19f5335a5',
       info_box: {
         source: 'custom',
-        information: {
-          contact: {
-            key: 'contact_value_rocklab_mont-terri',
-            url: 'contact_url_rocklab_mont-terri',
+        information: [
+          {
+            key: 'contact',
+            value: {
+              key: 'contact_value_rocklab_mont-terri',
+              url: 'contact_url_rocklab_mont-terri',
+            },
           },
-        },
+        ],
       },
     },
     // Tunnel

--- a/layers/layers_3dtiles.json5
+++ b/layers/layers_3dtiles.json5
@@ -448,19 +448,31 @@
       //order_of_properties: '',
       info_box: {
         source: 'custom',
-        information: {
-          contact: { key: 'contact_value', url: 'contact_url' },
-          description: { key: 'description_value', url: 'description_url' },
-          download_01: {
-            key: 'download_movz_value',
-            url: 'download_movz_url_j3d_horizon',
+        information: [
+          {
+            key: 'contact',
+            value: { key: 'contact_value', url: 'contact_url' },
           },
-          download_02: {
-            key: 'download_gocad_value',
-            url: 'download_gocad_url_j3d_horizon',
+          {
+            key: 'description',
+            value: { key: 'description_value', url: 'description_url' },
           },
-          dataDate: '18.03.2026',
-        },
+          {
+            key: 'download_01',
+            value: {
+              key: 'download_movz_value',
+              url: 'download_movz_url_j3d_horizon',
+            },
+          },
+          {
+            key: 'download_02',
+            value: {
+              key: 'download_gocad_value',
+              url: 'download_gocad_url_j3d_horizon',
+            },
+          },
+          { key: 'dataDate', value: '18.03.2026' },
+        ],
       },
     },
     // Faults
@@ -474,19 +486,31 @@
       //order_of_properties: '',
       info_box: {
         source: 'custom',
-        information: {
-          contact: { key: 'contact_value', url: 'contact_url' },
-          description: { key: 'description_value', url: 'description_url' },
-          download_01: {
-            key: 'download_movz_value',
-            url: 'download_movz_url_j3d_faults',
+        information: [
+          {
+            key: 'contact',
+            value: { key: 'contact_value', url: 'contact_url' },
           },
-          download_02: {
-            key: 'download_gocad_value',
-            url: 'download_gocad_url_j3d_faults',
+          {
+            key: 'description',
+            value: { key: 'description_value', url: 'description_url' },
           },
-          dataDate: '18.03.2026',
-        },
+          {
+            key: 'download_01',
+            value: {
+              key: 'download_movz_value',
+              url: 'download_movz_url_j3d_faults',
+            },
+          },
+          {
+            key: 'download_02',
+            value: {
+              key: 'download_gocad_value',
+              url: 'download_gocad_url_j3d_faults',
+            },
+          },
+          { key: 'dataDate', value: '18.03.2026' },
+        ],
       },
     },
     // Cross-section (profile)
@@ -500,19 +524,31 @@
       //order_of_properties: '',
       info_box: {
         source: 'custom',
-        information: {
-          contact: { key: 'contact_value', url: 'contact_url' },
-          description: { key: 'description_value', url: 'description_url' },
-          download_01: {
-            key: 'download_movz_value',
-            url: 'download_movz_url_j3d_profiles',
+        information: [
+          {
+            key: 'contact',
+            value: { key: 'contact_value', url: 'contact_url' },
           },
-          download_02: {
-            key: 'download_shp_value',
-            url: 'download_shp_url_j3d_profiles',
+          {
+            key: 'description',
+            value: { key: 'description_value', url: 'description_url' },
           },
-          dataDate: '18.03.2026',
-        },
+          {
+            key: 'download_01',
+            value: {
+              key: 'download_movz_value',
+              url: 'download_movz_url_j3d_profiles',
+            },
+          },
+          {
+            key: 'download_02',
+            value: {
+              key: 'download_shp_value',
+              url: 'download_shp_url_j3d_profiles',
+            },
+          },
+          { key: 'dataDate', value: '18.03.2026' },
+        ],
       },
     },
     // GeoMol

--- a/ui/src/features/catalog/display/details/catalog-display-legend-detail.element.ts
+++ b/ui/src/features/catalog/display/details/catalog-display-legend-detail.element.ts
@@ -7,7 +7,6 @@ import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import { CoreElement } from 'src/features/core';
 import {
   InfoBoxCustom,
-  InformationEntry,
   InformationValue,
   Layer,
 } from 'src/features/layer';
@@ -120,7 +119,7 @@ export class CatalogDisplayInfoBox extends CoreElement {
   };
 
   private readonly renderInformation = (infoBox: InfoBoxCustom) => {
-    const informationEntries = this.getInformationEntries(infoBox.information);
+    const informationEntries = infoBox.information ?? [];
     if (informationEntries.length === 0) {
       return nothing;
     }
@@ -145,17 +144,6 @@ export class CatalogDisplayInfoBox extends CoreElement {
     `;
   };
 
-  private readonly getInformationEntries = (
-    information: InfoBoxCustom['information'],
-  ): InformationEntry[] => {
-    if (information === undefined) {
-      return [];
-    }
-    if (Array.isArray(information)) {
-      return information;
-    }
-    return Object.entries(information).map(([key, value]) => ({ key, value }));
-  };
 
   private readonly getInformationKeyTitle = (key: string): string => {
     return i18next.t(`layers:info_box.information.${key}`);

--- a/ui/src/features/catalog/display/details/catalog-display-legend-detail.element.ts
+++ b/ui/src/features/catalog/display/details/catalog-display-legend-detail.element.ts
@@ -122,10 +122,13 @@ export class CatalogDisplayInfoBox extends CoreElement {
     return html`
       <table class="info-table">
         ${informationEntries.map(
-          ({ key, value }) => html`
+          ({ labelKey, value }) => html`
             <tr>
-              <td class="info-key" title=${this.getInformationKeyTitle(key)}>
-                ${this.getInformationKeyTitle(key)}
+              <td
+                class="info-key"
+                title=${this.getInformationKeyTitle(labelKey)}
+              >
+                ${this.getInformationKeyTitle(labelKey)}
               </td>
               <td
                 class="info-value"

--- a/ui/src/features/catalog/display/details/catalog-display-legend-detail.element.ts
+++ b/ui/src/features/catalog/display/details/catalog-display-legend-detail.element.ts
@@ -5,11 +5,7 @@ import { customElement, property, state } from 'lit/decorators.js';
 import i18next from 'i18next';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import { CoreElement } from 'src/features/core';
-import {
-  InfoBoxCustom,
-  InformationValue,
-  Layer,
-} from 'src/features/layer';
+import { InfoBoxCustom, InformationValue, Layer } from 'src/features/layer';
 import { run } from 'src/utils/fn.utils';
 import { Id } from 'src/models/id.model';
 import { LayerService } from 'src/features/layer/layer.service';
@@ -143,7 +139,6 @@ export class CatalogDisplayInfoBox extends CoreElement {
       </table>
     `;
   };
-
 
   private readonly getInformationKeyTitle = (key: string): string => {
     return i18next.t(`layers:info_box.information.${key}`);

--- a/ui/src/features/catalog/display/details/catalog-display-legend-detail.element.ts
+++ b/ui/src/features/catalog/display/details/catalog-display-legend-detail.element.ts
@@ -5,7 +5,12 @@ import { customElement, property, state } from 'lit/decorators.js';
 import i18next from 'i18next';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import { CoreElement } from 'src/features/core';
-import { InfoBoxCustom, InformationValue, Layer } from 'src/features/layer';
+import {
+  InfoBoxCustom,
+  InformationEntry,
+  InformationValue,
+  Layer,
+} from 'src/features/layer';
 import { run } from 'src/utils/fn.utils';
 import { Id } from 'src/models/id.model';
 import { LayerService } from 'src/features/layer/layer.service';
@@ -115,13 +120,14 @@ export class CatalogDisplayInfoBox extends CoreElement {
   };
 
   private readonly renderInformation = (infoBox: InfoBoxCustom) => {
-    if (!infoBox.information || Object.keys(infoBox.information).length === 0) {
+    const informationEntries = this.getInformationEntries(infoBox.information);
+    if (informationEntries.length === 0) {
       return nothing;
     }
     return html`
       <table class="info-table">
-        ${Object.entries(infoBox.information).map(
-          ([key, value]) => html`
+        ${informationEntries.map(
+          ({ key, value }) => html`
             <tr>
               <td class="info-key" title=${this.getInformationKeyTitle(key)}>
                 ${this.getInformationKeyTitle(key)}
@@ -137,6 +143,18 @@ export class CatalogDisplayInfoBox extends CoreElement {
         )}
       </table>
     `;
+  };
+
+  private readonly getInformationEntries = (
+    information: InfoBoxCustom['information'],
+  ): InformationEntry[] => {
+    if (information === undefined) {
+      return [];
+    }
+    if (Array.isArray(information)) {
+      return information;
+    }
+    return Object.entries(information).map(([key, value]) => ({ key, value }));
   };
 
   private readonly getInformationKeyTitle = (key: string): string => {

--- a/ui/src/features/layer/layer-api.service.ts
+++ b/ui/src/features/layer/layer-api.service.ts
@@ -9,7 +9,6 @@ import {
   GeoJsonLayer,
   InfoBox,
   InfoBoxCustom,
-  InformationEntry,
   KmlLayer,
   Layer,
   LayerGroup,
@@ -113,7 +112,7 @@ export class LayerApiService extends BaseService {
           const information: InfoBoxCustom['information'] | null =
             infoBoxValue.takeNullable('information');
           if (information !== null) {
-            result.information = this.normalizeInformationEntries(information);
+            result.information = information;
           }
           return result;
         }
@@ -402,17 +401,6 @@ export class LayerApiService extends BaseService {
     }
   };
 
-  private readonly normalizeInformationEntries = (
-    information: InfoBoxCustom['information'],
-  ): InformationEntry[] => {
-    if (information === undefined) {
-      return [];
-    }
-    if (Array.isArray(information)) {
-      return information;
-    }
-    return Object.entries(information).map(([key, value]) => ({ key, value }));
-  };
 }
 
 type Specific<L extends Layer> = Omit<L, keyof BaseLayer>;

--- a/ui/src/features/layer/layer-api.service.ts
+++ b/ui/src/features/layer/layer-api.service.ts
@@ -9,7 +9,7 @@ import {
   GeoJsonLayer,
   InfoBox,
   InfoBoxCustom,
-  InformationValue,
+  InformationEntry,
   KmlLayer,
   Layer,
   LayerGroup,
@@ -110,10 +110,10 @@ export class LayerApiService extends BaseService {
           if (legendUrl !== null) {
             result.legendUrl = legendUrl;
           }
-          const information: Record<string, InformationValue> | null =
+          const information: InfoBoxCustom['information'] | null =
             infoBoxValue.takeNullable('information');
           if (information !== null) {
-            result.information = information;
+            result.information = this.normalizeInformationEntries(information);
           }
           return result;
         }
@@ -400,6 +400,18 @@ export class LayerApiService extends BaseService {
           type: OgcSourceType.Wms,
         };
     }
+  };
+
+  private readonly normalizeInformationEntries = (
+    information: InfoBoxCustom['information'],
+  ): InformationEntry[] => {
+    if (information === undefined) {
+      return [];
+    }
+    if (Array.isArray(information)) {
+      return information;
+    }
+    return Object.entries(information).map(([key, value]) => ({ key, value }));
   };
 }
 

--- a/ui/src/features/layer/layer-api.service.ts
+++ b/ui/src/features/layer/layer-api.service.ts
@@ -400,7 +400,6 @@ export class LayerApiService extends BaseService {
         };
     }
   };
-
 }
 
 type Specific<L extends Layer> = Omit<L, keyof BaseLayer>;

--- a/ui/src/features/layer/models/layer.model.ts
+++ b/ui/src/features/layer/models/layer.model.ts
@@ -140,18 +140,10 @@ export interface InformationEntry {
   value: InformationValue;
 }
 
-export type InformationEntries =
-  | InformationEntry[]
-  | Record<string, InformationValue>;
-
 export interface InfoBoxCustom {
   source: 'custom';
   legendUrl?: string;
-  /**
-   * Preferred format: ordered array (`[{ key, value }, ...]`).
-   * Legacy format: object map (`{ [key]: value }`).
-   */
-  information?: InformationEntries;
+  information?: InformationEntry[];
 }
 
 export const getLayerLabel = (layer: AnyLayer): string =>

--- a/ui/src/features/layer/models/layer.model.ts
+++ b/ui/src/features/layer/models/layer.model.ts
@@ -118,8 +118,7 @@ export enum LayerType {
  *
  * - `api3.geo.admin.ch`: The legend is fetched as HTML from `api3.geo.admin.ch` via the layer's id.
  * - `custom`: Displays translated info text (derived from the layer id), an optional URL,
- *   and optional key-value pairs (`information`). The key is a translation key for the label
- *   and the value is an {@link InformationValue}.
+ *   and optional `information` entries.
  */
 export type InfoBox = InfoBoxApi3GeoAdminCh | InfoBoxCustom;
 
@@ -136,10 +135,23 @@ export interface InfoBoxApi3GeoAdminCh {
  */
 export type InformationValue = string | { key: string; url: string };
 
+export interface InformationEntry {
+  key: string;
+  value: InformationValue;
+}
+
+export type InformationEntries =
+  | InformationEntry[]
+  | Record<string, InformationValue>;
+
 export interface InfoBoxCustom {
   source: 'custom';
   legendUrl?: string;
-  information?: Record<string, InformationValue>;
+  /**
+   * Preferred format: ordered array (`[{ key, value }, ...]`).
+   * Legacy format: object map (`{ [key]: value }`).
+   */
+  information?: InformationEntries;
 }
 
 export const getLayerLabel = (layer: AnyLayer): string =>

--- a/ui/src/features/layer/models/layer.model.ts
+++ b/ui/src/features/layer/models/layer.model.ts
@@ -136,7 +136,7 @@ export interface InfoBoxApi3GeoAdminCh {
 export type InformationValue = string | { key: string; url: string };
 
 export interface InformationEntry {
-  key: string;
+  labelKey: string;
   value: InformationValue;
 }
 


### PR DESCRIPTION
#1951
By changing the structure of the layer configurations to contain array, it is now possible to strictly define the order of the information entries by reordering items in the layer configurations