### PR TITLE
#2002 error handling and loading indicator

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -132,11 +132,32 @@ jobs:
           cd ui
           npm run lint
 
+  test-ui:
+    name: 'Test UI'
+    runs-on: ubuntu-latest
+    needs:
+      - check-ui
+      - lint-ui
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - name: Restore cached node modules
+        uses: actions/cache/restore@v4
+        with:
+          path: ./ui/node_modules
+          key: "${{ runner.os }}-node_modules-${{ env.NODE_VERSION }}-${{ hashFiles('./ui/package-lock.json') }}"
+      - name: Run unit tests
+        run: cd ui && npm test
+
   build-ui:
     name: 'Build UI'
     runs-on: ubuntu-latest
     needs:
-      - lint-ui
+      - test-ui
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/ui/locales/layout/layout.de.json
+++ b/ui/locales/layout/layout.de.json
@@ -24,6 +24,13 @@
       "opacity": "Filter Deckkraft",
       "resetAll": "Alle Filter zurücksetzen",
       "loadError": "Fehler beim Laden"
+    },
+    "errors": {
+      "loadDatasets": "Die verfügbaren Lexic-Datensätze konnten nicht geladen werden.",
+      "generateWmsRequest_one": "Der ausgewählte Lexic-Filter konnte nicht auf die Karte angewendet werden.",
+      "generateWmsRequest_other": "Die ausgewählten Lexic-Filter konnten nicht auf die Karte angewendet werden.",
+      "loadFilterTerms": "Die Lexic-Filterbegriffe konnten nicht geladen werden.",
+      "loadTiles": "Die Lexic-Filterkacheln konnten nicht geladen werden."
     }
   }
 }

--- a/ui/locales/layout/layout.de.json
+++ b/ui/locales/layout/layout.de.json
@@ -14,7 +14,8 @@
     "filter": {
       "reset": "Zurücksetzen",
       "addFilter": "Filter hinzufügen",
-      "or": "OR",
+      "or": "ODER",
+      "and": "UND",
       "dialogTitle": "Filter – {{title}}",
       "searchPlaceholder": "{{title}} suchen ...",
       "includeNarrowers": "Untergeordnete einschliessen (Children)",

--- a/ui/locales/layout/layout.en.json
+++ b/ui/locales/layout/layout.en.json
@@ -24,6 +24,13 @@
       "opacity": "Filter opacity",
       "resetAll": "Reset all filters",
       "loadError": "Error loading results"
+    },
+    "errors": {
+      "loadDatasets": "Could not load the available Lexic datasets.",
+      "generateWmsRequest_one": "Could not apply the selected Lexic filter to the map.",
+      "generateWmsRequest_other": "Could not apply the selected Lexic filters to the map.",
+      "loadFilterTerms": "Could not load the Lexic filter terms.",
+      "loadTiles": "Could not load the Lexic filter map tiles."
     }
   }
 }

--- a/ui/locales/layout/layout.en.json
+++ b/ui/locales/layout/layout.en.json
@@ -15,6 +15,7 @@
       "reset": "Reset",
       "addFilter": "Add filter",
       "or": "OR",
+      "and": "AND",
       "dialogTitle": "Filter – {{title}}",
       "searchPlaceholder": "{{title}} search ...",
       "includeNarrowers": "Include Narrowers (Children)",

--- a/ui/locales/layout/layout.fr.json
+++ b/ui/locales/layout/layout.fr.json
@@ -24,6 +24,13 @@
       "opacity": "Opacité du filtre",
       "resetAll": "Réinitialiser tous les filtres",
       "loadError": "Erreur lors du chargement"
+    },
+    "errors": {
+      "loadDatasets": "Impossible de charger les jeux de données Lexic disponibles.",
+      "generateWmsRequest_one": "Impossible d'appliquer le filtre Lexic sélectionné à la carte.",
+      "generateWmsRequest_other": "Impossible d'appliquer les filtres Lexic sélectionnés à la carte.",
+      "loadFilterTerms": "Impossible de charger les termes de filtre Lexic.",
+      "loadTiles": "Impossible de charger les tuiles de carte du filtre Lexic."
     }
   }
 }

--- a/ui/locales/layout/layout.fr.json
+++ b/ui/locales/layout/layout.fr.json
@@ -14,7 +14,8 @@
     "filter": {
       "reset": "Réinitialiser",
       "addFilter": "Ajouter un filtre",
-      "or": "OR",
+      "or": "OU",
+      "and": "ET",
       "dialogTitle": "Filtre – {{title}}",
       "searchPlaceholder": "Rechercher {{title}} ...",
       "includeNarrowers": "Inclure les sous-catégories (Children)",

--- a/ui/locales/layout/layout.it.json
+++ b/ui/locales/layout/layout.it.json
@@ -24,6 +24,13 @@
       "opacity": "Opacità del filtro",
       "resetAll": "Ripristina tutti i filtri",
       "loadError": "Errore durante il caricamento"
+    },
+    "errors": {
+      "loadDatasets": "Impossibile caricare i set di dati Lexic disponibili.",
+      "generateWmsRequest_one": "Impossibile applicare il filtro Lexic selezionato alla mappa.",
+      "generateWmsRequest_other": "Impossibile applicare i filtri Lexic selezionati alla mappa.",
+      "loadFilterTerms": "Impossibile caricare i termini del filtro Lexic.",
+      "loadTiles": "Impossibile caricare le tessere della mappa del filtro Lexic."
     }
   }
 }

--- a/ui/locales/layout/layout.it.json
+++ b/ui/locales/layout/layout.it.json
@@ -14,7 +14,8 @@
     "filter": {
       "reset": "Ripristina",
       "addFilter": "Aggiungi filtro",
-      "or": "OR",
+      "or": "O",
+      "and": "E",
       "dialogTitle": "Filtro – {{title}}",
       "searchPlaceholder": "Cerca {{title}} ...",
       "includeNarrowers": "Includi sottocategorie (Children)",

--- a/ui/package.json
+++ b/ui/package.json
@@ -18,6 +18,8 @@
     "check": "npm run check:src && npm run check:cypress",
     "check:src": "tsc -p tsconfig.json --noEmit",
     "check:cypress": "tsc -b . && cd cypress && tsc -p tsconfig.json --noEmit",
+    "test": "vitest run --config vitest.config.ts",
+    "test:watch": "vitest --config vitest.config.ts",
     "test:ogc": "vitest run --config vitest.ogc.config.ts",
     "e2e": "start-server-and-test start http-get://localhost:8000 cypress:run",
     "cypress:open": "cypress open --config-file cypress/cypress.config.ts",

--- a/ui/src/features/lexic/README.md
+++ b/ui/src/features/lexic/README.md
@@ -2,9 +2,9 @@
 
 ## URL Parameters
 
-| Parameter          | Default | Description                                                                                                    |
-| ------------------ | ------- | -------------------------------------------------------------------------------------------------------------- |
-| `lexicSingleTile`  | `false` | Set to `true` to use a single untiled image instead of tiled WMS requests for the filter overlay (fewer requests, but lower quality at high zoom). |
+| Parameter         | Default | Description                                                                                                                                        |
+| ----------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `lexicSingleTile` | `false` | Set to `true` to use a single untiled image instead of tiled WMS requests for the filter overlay (fewer requests, but lower quality at high zoom). |
 
 Example: `https://viewer.swissgeol.ch/?lexicSingleTile=true`
 

--- a/ui/src/features/lexic/lexic-filter-container.element.ts
+++ b/ui/src/features/lexic/lexic-filter-container.element.ts
@@ -1,4 +1,5 @@
 import { consume } from '@lit/context';
+import i18next from 'i18next';
 import { css, html, nothing } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { CoreElement } from 'src/features/core';
@@ -193,7 +194,7 @@ export class LexicFilterContainer extends CoreElement {
 
   private readonly renderAndSeparator = () => html`
     <div class="and-separator">
-      <span class="and-label">AND</span>
+      <span class="and-label">${i18next.t('layout:lexic.filter.and')}</span>
     </div>
   `;
 

--- a/ui/src/features/lexic/lexic-filter-dialog.element.ts
+++ b/ui/src/features/lexic/lexic-filter-dialog.element.ts
@@ -4,6 +4,7 @@ import { css, html, nothing } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { CoreElement } from 'src/features/core';
 import { CoreModal } from 'src/features/core/core-modal.element';
+import { showSnackbarError } from 'src/notifications';
 import { applyTypography } from 'src/styles/theme';
 import { LexicFilterId, LexicLanguage } from './lexic-api.model';
 import { LexicFilterService } from './lexic-filter.service';
@@ -110,8 +111,12 @@ export class LexicFilterDialog extends CoreElement {
         this.getLexicLanguage(),
       );
       this.terms = response.terms ?? [];
-    } catch {
+    } catch (error) {
+      console.error('[Lexic] Failed to load filter terms:', error);
       this.terms = [];
+      showSnackbarError(i18next.t('layout:lexic.errors.loadFilterTerms'));
+      this.closeDialog();
+      return;
     } finally {
       this.isLoading = false;
       this.focusedIndex = -1;

--- a/ui/src/features/lexic/lexic-filter-panel.element.ts
+++ b/ui/src/features/lexic/lexic-filter-panel.element.ts
@@ -210,7 +210,6 @@ export class LexicFilterPanel extends CoreElement {
       console.error('[Lexic] Failed to load datasets:', error);
       this.layers = [];
       this.webmapId = '';
-      this.isLoadingLayers = false;
       // Only surface the error when the panel is open — otherwise datasets
       // are retried the next time the panel is opened.
       if (this.filterService.isOpen) {

--- a/ui/src/features/lexic/lexic-filter-panel.element.ts
+++ b/ui/src/features/lexic/lexic-filter-panel.element.ts
@@ -50,6 +50,9 @@ export class LexicFilterPanel extends CoreElement {
   @state()
   accessor isLoadingFilters = false;
 
+  @state()
+  accessor isLoadingResults = false;
+
   private filtersRequestVersion = 0;
   private webmapId = '';
 
@@ -61,7 +64,12 @@ export class LexicFilterPanel extends CoreElement {
         const wasOpen = this.isOpen;
         this.isOpen = isOpen;
         // Retry loading datasets when the panel is opened and none are available yet.
-        if (isOpen && !wasOpen && this.layers.length === 0 && !this.isLoadingLayers) {
+        if (
+          isOpen &&
+          !wasOpen &&
+          this.layers.length === 0 &&
+          !this.isLoadingLayers
+        ) {
           void this.loadLayerOptions();
         }
       }),
@@ -69,6 +77,11 @@ export class LexicFilterPanel extends CoreElement {
     this.register(
       this.filterService.selectedDatasetId$.subscribe((id) => {
         this.selectedLayerId = id;
+      }),
+    );
+    this.register(
+      this.filterService.resultState$.subscribe((state) => {
+        this.isLoadingResults = state === 'loading';
       }),
     );
 
@@ -234,9 +247,18 @@ export class LexicFilterPanel extends CoreElement {
     return html`
       <div class="floating-panel">
         <header class="panel-header">
-          <span class="panel-title"
-            >${i18next.t('layout:items.Lexic')} Filter</span
-          >
+          <div class="panel-header-leading">
+            <span class="panel-title"
+              >${i18next.t('layout:items.Lexic')} Filter</span
+            >
+            ${this.isLoadingResults
+              ? html`<sgc-icon
+                  name="spinner"
+                  animation="spin"
+                  aria-hidden="true"
+                ></sgc-icon>`
+              : nothing}
+          </div>
           <ngm-core-icon
             icon="close"
             interactive
@@ -310,10 +332,26 @@ export class LexicFilterPanel extends CoreElement {
       display: flex;
       align-items: center;
       justify-content: space-between;
+      gap: 12px;
       padding: 14px 16px;
       background-color: var(--color-bg--dark);
       border-bottom: 1px solid #e0e2e6;
       flex-shrink: 0;
+    }
+
+    .panel-header-leading {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      min-width: 0;
+      flex: 1;
+    }
+
+    .panel-header-leading > sgc-icon {
+      flex-shrink: 0;
+      width: 18px;
+      height: 18px;
+      color: var(--color-primary);
     }
 
     .panel-title {

--- a/ui/src/features/lexic/lexic-filter-panel.element.ts
+++ b/ui/src/features/lexic/lexic-filter-panel.element.ts
@@ -3,6 +3,7 @@ import i18next from 'i18next';
 import { css, html, nothing } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { CoreElement } from 'src/features/core';
+import { showSnackbarError } from 'src/notifications';
 import { applyTypography } from 'src/styles/theme';
 import { LexicApiService } from './lexic-api.service';
 import { LexicFilterService } from './lexic-filter.service';
@@ -57,7 +58,12 @@ export class LexicFilterPanel extends CoreElement {
 
     this.register(
       this.filterService.isOpen$.subscribe((isOpen) => {
+        const wasOpen = this.isOpen;
         this.isOpen = isOpen;
+        // Retry loading datasets when the panel is opened and none are available yet.
+        if (isOpen && !wasOpen && this.layers.length === 0 && !this.isLoadingLayers) {
+          void this.loadLayerOptions();
+        }
       }),
     );
     this.register(
@@ -188,14 +194,17 @@ export class LexicFilterPanel extends CoreElement {
       );
       this.webmapId = response.webmapId ?? '';
     } catch (error) {
-      // FIXME: Remove this stub fallback once the Lexic API is reachable
-      // without CORS issues (e.g. when a proxy or proper CORS headers are in place).
-      console.warn(
-        '[Lexic] getLayers API call failed, falling back to stub layers:',
-        error,
-      );
+      console.error('[Lexic] Failed to load datasets:', error);
       this.layers = [];
-      this.webmapId = 'SwissTopoMap';
+      this.webmapId = '';
+      this.isLoadingLayers = false;
+      // Only surface the error when the panel is open — otherwise datasets
+      // are retried the next time the panel is opened.
+      if (this.filterService.isOpen) {
+        showSnackbarError(i18next.t('layout:lexic.errors.loadDatasets'));
+        this.handleClose();
+      }
+      return;
     } finally {
       this.isLoadingLayers = false;
     }

--- a/ui/src/features/lexic/lexic-filter.service.test.ts
+++ b/ui/src/features/lexic/lexic-filter.service.test.ts
@@ -36,6 +36,13 @@ function createService() {
 
   const mockViewer = {
     scene: {
+      globe: {
+        tilesLoaded: true,
+        tileLoadProgressEvent: {
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+        },
+      },
       imageryLayers: {
         add: vi.fn(),
         remove: vi.fn(),
@@ -71,6 +78,7 @@ function createService() {
 describe('LexicFilterService', () => {
   beforeEach(() => {
     vi.stubGlobal('fetch', vi.fn());
+    vi.mocked(showSnackbarError).mockClear();
   });
 
   afterEach(() => {
@@ -420,6 +428,11 @@ describe('LexicFilterService', () => {
       expect(showSnackbarError).toHaveBeenCalledTimes(1);
       expect(showSnackbarError).toHaveBeenCalledWith(
         'layout:lexic.errors.loadTiles',
+      );
+
+      (service as any).detachImageryErrorHandler();
+      expect(mockProvider.errorEvent.removeEventListener).toHaveBeenCalledWith(
+        listeners[0],
       );
     });
 

--- a/ui/src/features/lexic/lexic-filter.service.test.ts
+++ b/ui/src/features/lexic/lexic-filter.service.test.ts
@@ -3,6 +3,17 @@ import { LexicFilterService, LexicResultState } from './lexic-filter.service';
 import { LexicApiService } from './lexic-api.service';
 import { CesiumService } from 'src/services/cesium.service';
 import { WmsRequestFiltersFilterId } from './generated/lexic-schemas';
+import { showSnackbarError } from 'src/notifications';
+
+vi.mock('src/notifications', () => ({
+  showSnackbarError: vi.fn(),
+}));
+
+vi.mock('i18next', () => ({
+  default: {
+    t: (key: string) => key,
+  },
+}));
 
 const LITHOLOGY_FILTER_ID = WmsRequestFiltersFilterId['f-lithology-term'];
 const LITHOSTRAT_FILTER_ID = WmsRequestFiltersFilterId['f-lithostrat-term'];
@@ -364,6 +375,52 @@ describe('LexicFilterService', () => {
       await vi.waitFor(() => {
         expect(states).toContain('load-error');
       });
+
+      expect(showSnackbarError).toHaveBeenCalledWith(
+        'layout:lexic.errors.generateWmsRequest',
+      );
+    });
+
+    it('shows a tile load error toast at most once per update version', () => {
+      const { service } = createService();
+
+      (service as any).showTileLoadError(1);
+      (service as any).showTileLoadError(1);
+
+      expect(showSnackbarError).toHaveBeenCalledTimes(1);
+      expect(showSnackbarError).toHaveBeenCalledWith(
+        'layout:lexic.errors.loadTiles',
+      );
+
+      (service as any).showTileLoadError(2);
+      expect(showSnackbarError).toHaveBeenCalledTimes(2);
+    });
+
+    it('attaches imagery error listeners that surface tile load errors', () => {
+      const { service } = createService();
+      const listeners: Array<() => void> = [];
+      const mockProvider = {
+        errorEvent: {
+          addEventListener: vi.fn((listener: () => void) => {
+            listeners.push(listener);
+          }),
+          removeEventListener: vi.fn(),
+        },
+      };
+
+      (service as any).updateVersion = 5;
+      (service as any).attachImageryErrorHandler(mockProvider, 5);
+
+      expect(mockProvider.errorEvent.addEventListener).toHaveBeenCalled();
+
+      vi.mocked(showSnackbarError).mockClear();
+      listeners[0]();
+      listeners[0]();
+
+      expect(showSnackbarError).toHaveBeenCalledTimes(1);
+      expect(showSnackbarError).toHaveBeenCalledWith(
+        'layout:lexic.errors.loadTiles',
+      );
     });
 
     it('transitions through loading → ok on successful WMS response', async () => {

--- a/ui/src/features/lexic/lexic-filter.service.ts
+++ b/ui/src/features/lexic/lexic-filter.service.ts
@@ -19,6 +19,7 @@ import {
   ImageryLayer,
   ImageryProvider,
   SingleTileImageryProvider,
+  Viewer,
   WebMapServiceImageryProvider,
 } from 'cesium';
 import {
@@ -92,6 +93,8 @@ export class LexicFilterService extends BaseService {
   private lexicApiService: LexicApiService | null = null;
   private layerAddedListener: (() => void) | null = null;
   private imageryErrorListener: (() => void) | null = null;
+  private tileProgressListener: ((queueLength: number) => void) | null = null;
+  private tileProgressResolve: (() => void) | null = null;
 
   private initializeServices(): void {
     const cesium$ = CesiumService.inject$<CesiumService>(CesiumService);
@@ -368,6 +371,65 @@ export class LexicFilterService extends BaseService {
     imageryLayers.layerAdded.addEventListener(this.layerAddedListener);
 
     viewer.scene.requestRender();
+    await this.waitForInitialTiles(viewer, version);
+  }
+
+  /**
+   * Waits until Cesium finishes loading tiles after the filtered imagery layer
+   * is added. Stays pending until the globe reports tiles loaded (or the wait
+   * is cancelled by a newer update / tile error).
+   */
+  private async waitForInitialTiles(
+    viewer: Viewer,
+    version: number,
+  ): Promise<void> {
+    if (version !== this.updateVersion) return;
+
+    const globe = viewer.scene.globe;
+    if (
+      globe.tileLoadProgressEvent == null ||
+      typeof globe.tileLoadProgressEvent.addEventListener !== 'function'
+    ) {
+      return;
+    }
+
+    this.finishTileWait(globe);
+
+    await new Promise<void>((resolve) => {
+      let sawPendingTiles = false;
+
+      this.tileProgressResolve = resolve;
+      this.tileProgressListener = (queueLength: number) => {
+        if (version !== this.updateVersion) {
+          this.finishTileWait(globe);
+          return;
+        }
+        if (queueLength > 0) {
+          sawPendingTiles = true;
+        }
+        if (sawPendingTiles && queueLength === 0 && globe.tilesLoaded) {
+          this.finishTileWait(globe);
+        }
+      };
+      globe.tileLoadProgressEvent.addEventListener(this.tileProgressListener);
+      viewer.scene.requestRender();
+    });
+  }
+
+  private finishTileWait(globe?: {
+    tileLoadProgressEvent?: {
+      removeEventListener: (listener: (queueLength: number) => void) => void;
+    };
+  }): void {
+    if (this.tileProgressListener != null) {
+      globe?.tileLoadProgressEvent?.removeEventListener?.(
+        this.tileProgressListener,
+      );
+      this.tileProgressListener = null;
+    }
+    const resolve = this.tileProgressResolve;
+    this.tileProgressResolve = null;
+    resolve?.();
   }
 
   private attachImageryErrorHandler(
@@ -378,6 +440,9 @@ export class LexicFilterService extends BaseService {
     this.imageryErrorListener = () => {
       if (version !== this.updateVersion) return;
       this.showTileLoadError(version);
+      this.finishTileWait(
+        this.cesiumService?.viewerOrNull?.scene?.globe,
+      );
     };
     provider.errorEvent.addEventListener(this.imageryErrorListener);
   }
@@ -427,6 +492,7 @@ export class LexicFilterService extends BaseService {
 
   private removeFilteredLayer(): void {
     this.detachImageryErrorHandler();
+    this.finishTileWait(this.cesiumService?.viewerOrNull?.scene?.globe);
 
     if (this.currentImagery == null) return;
 

--- a/ui/src/features/lexic/lexic-filter.service.ts
+++ b/ui/src/features/lexic/lexic-filter.service.ts
@@ -280,7 +280,7 @@ export class LexicFilterService extends BaseService {
 
     this._resultState$.next('loading');
 
-    let wmsResponse;
+    let wmsResponse: { body: string };
     try {
       wmsResponse = await this.lexicApiService.generateWmsRequest({
         webmapId: this._webmapId,

--- a/ui/src/features/lexic/lexic-filter.service.ts
+++ b/ui/src/features/lexic/lexic-filter.service.ts
@@ -17,6 +17,7 @@ import { FilterId } from 'src/features/lexic/generated/lexic-schemas';
 import {
   Credit,
   ImageryLayer,
+  ImageryProvider,
   SingleTileImageryProvider,
   WebMapServiceImageryProvider,
 } from 'cesium';
@@ -27,6 +28,8 @@ import {
   SWITZERLAND_RECTANGLE,
   WEB_MERCATOR_TILING_SCHEME,
 } from 'src/constants';
+import { showSnackbarError } from 'src/notifications';
+import i18next from 'i18next';
 
 export type LexicResultState = 'idle' | 'loading' | 'ok' | 'load-error';
 
@@ -83,10 +86,12 @@ export class LexicFilterService extends BaseService {
 
   private currentImagery: ImageryLayer | null = null;
   private updateVersion = 0;
+  private tileErrorShownForVersion = -1;
   private servicesSubscription: Subscription | null = null;
   private cesiumService: CesiumService | null = null;
   private lexicApiService: LexicApiService | null = null;
   private layerAddedListener: (() => void) | null = null;
+  private imageryErrorListener: (() => void) | null = null;
 
   private initializeServices(): void {
     const cesium$ = CesiumService.inject$<CesiumService>(CesiumService);
@@ -272,25 +277,41 @@ export class LexicFilterService extends BaseService {
 
     this._resultState$.next('loading');
 
+    let wmsResponse;
     try {
-      const wmsResponse = await this.lexicApiService.generateWmsRequest({
+      wmsResponse = await this.lexicApiService.generateWmsRequest({
         webmapId: this._webmapId,
         layerId: this._selectedLayerId,
         filters,
       });
-
-      // Discard if a newer update was triggered in the meantime
-      if (version !== this.updateVersion) return;
-
-      await this.applyWmsLayer(wmsResponse.body, version);
-      if (version === this.updateVersion) {
-        this._resultState$.next('ok');
-      }
     } catch (error) {
       console.error('[Lexic] Failed to generate WMS request:', error);
       if (version === this.updateVersion) {
         this.removeFilteredLayer();
         this._resultState$.next('load-error');
+        showSnackbarError(
+          i18next.t('layout:lexic.errors.generateWmsRequest', {
+            count: filters.length,
+          }),
+        );
+      }
+      return;
+    }
+
+    // Discard if a newer update was triggered in the meantime
+    if (version !== this.updateVersion) return;
+
+    try {
+      await this.applyWmsLayer(wmsResponse.body, version);
+      if (version === this.updateVersion) {
+        this._resultState$.next('ok');
+      }
+    } catch (error) {
+      console.error('[Lexic] Failed to load WMS tiles:', error);
+      if (version === this.updateVersion) {
+        this.removeFilteredLayer();
+        this._resultState$.next('load-error');
+        this.showTileLoadError(version);
       }
     }
   }
@@ -323,13 +344,15 @@ export class LexicFilterService extends BaseService {
       ? this.createSingleTileProvider(wmsBody)
       : this.createTiledWmsProvider(wmsBody);
 
+    // Remove previous filtered layer if present
+    this.removeFilteredLayer();
+
+    this.attachImageryErrorHandler(provider, version);
+
     const imagery = new ImageryLayer(provider, {
       show: true,
       alpha: this._resultOpacity$.value / 100,
     });
-
-    // Remove previous filtered layer if present
-    this.removeFilteredLayer();
 
     // Add on top of all existing layers
     imageryLayers.add(imagery);
@@ -345,6 +368,36 @@ export class LexicFilterService extends BaseService {
     imageryLayers.layerAdded.addEventListener(this.layerAddedListener);
 
     viewer.scene.requestRender();
+  }
+
+  private attachImageryErrorHandler(
+    provider: ImageryProvider,
+    version: number,
+  ): void {
+    this.detachImageryErrorHandler();
+    this.imageryErrorListener = () => {
+      if (version !== this.updateVersion) return;
+      this.showTileLoadError(version);
+    };
+    provider.errorEvent.addEventListener(this.imageryErrorListener);
+  }
+
+  private detachImageryErrorHandler(): void {
+    if (
+      this.imageryErrorListener != null &&
+      this.currentImagery?.imageryProvider != null
+    ) {
+      this.currentImagery.imageryProvider.errorEvent.removeEventListener(
+        this.imageryErrorListener,
+      );
+    }
+    this.imageryErrorListener = null;
+  }
+
+  private showTileLoadError(version: number): void {
+    if (this.tileErrorShownForVersion === version) return;
+    this.tileErrorShownForVersion = version;
+    showSnackbarError(i18next.t('layout:lexic.errors.loadTiles'));
   }
 
   private createSingleTileProvider(wmsBody: string): SingleTileImageryProvider {
@@ -373,6 +426,8 @@ export class LexicFilterService extends BaseService {
   }
 
   private removeFilteredLayer(): void {
+    this.detachImageryErrorHandler();
+
     if (this.currentImagery == null) return;
 
     const viewer = this.cesiumService?.viewerOrNull;

--- a/ui/src/features/lexic/lexic-filter.service.ts
+++ b/ui/src/features/lexic/lexic-filter.service.ts
@@ -19,7 +19,6 @@ import {
   ImageryLayer,
   ImageryProvider,
   SingleTileImageryProvider,
-  Viewer,
   WebMapServiceImageryProvider,
 } from 'cesium';
 import {
@@ -31,6 +30,7 @@ import {
 } from 'src/constants';
 import { showSnackbarError } from 'src/notifications';
 import i18next from 'i18next';
+import { LexicTileLoadWaiter } from './lexic-tile-load';
 
 export type LexicResultState = 'idle' | 'loading' | 'ok' | 'load-error';
 
@@ -93,8 +93,8 @@ export class LexicFilterService extends BaseService {
   private lexicApiService: LexicApiService | null = null;
   private layerAddedListener: (() => void) | null = null;
   private imageryErrorListener: (() => void) | null = null;
-  private tileProgressListener: ((queueLength: number) => void) | null = null;
-  private tileProgressResolve: (() => void) | null = null;
+  private imageryErrorProvider: ImageryProvider | null = null;
+  private readonly tileLoadWaiter = new LexicTileLoadWaiter();
 
   private initializeServices(): void {
     const cesium$ = CesiumService.inject$<CesiumService>(CesiumService);
@@ -350,8 +350,6 @@ export class LexicFilterService extends BaseService {
     // Remove previous filtered layer if present
     this.removeFilteredLayer();
 
-    this.attachImageryErrorHandler(provider, version);
-
     const imagery = new ImageryLayer(provider, {
       show: true,
       alpha: this._resultOpacity$.value / 100,
@@ -361,6 +359,7 @@ export class LexicFilterService extends BaseService {
     imageryLayers.add(imagery);
     imageryLayers.raiseToTop(imagery);
     this.currentImagery = imagery;
+    this.attachImageryErrorHandler(provider, version);
 
     // Keep layer on top when other layers are added
     this.layerAddedListener = () => {
@@ -371,65 +370,9 @@ export class LexicFilterService extends BaseService {
     imageryLayers.layerAdded.addEventListener(this.layerAddedListener);
 
     viewer.scene.requestRender();
-    await this.waitForInitialTiles(viewer, version);
-  }
-
-  /**
-   * Waits until Cesium finishes loading tiles after the filtered imagery layer
-   * is added. Stays pending until the globe reports tiles loaded (or the wait
-   * is cancelled by a newer update / tile error).
-   */
-  private async waitForInitialTiles(
-    viewer: Viewer,
-    version: number,
-  ): Promise<void> {
-    if (version !== this.updateVersion) return;
-
-    const globe = viewer.scene.globe;
-    if (
-      globe.tileLoadProgressEvent == null ||
-      typeof globe.tileLoadProgressEvent.addEventListener !== 'function'
-    ) {
-      return;
-    }
-
-    this.finishTileWait(globe);
-
-    await new Promise<void>((resolve) => {
-      let sawPendingTiles = false;
-
-      this.tileProgressResolve = resolve;
-      this.tileProgressListener = (queueLength: number) => {
-        if (version !== this.updateVersion) {
-          this.finishTileWait(globe);
-          return;
-        }
-        if (queueLength > 0) {
-          sawPendingTiles = true;
-        }
-        if (sawPendingTiles && queueLength === 0 && globe.tilesLoaded) {
-          this.finishTileWait(globe);
-        }
-      };
-      globe.tileLoadProgressEvent.addEventListener(this.tileProgressListener);
-      viewer.scene.requestRender();
+    await this.tileLoadWaiter.wait(viewer, {
+      isCurrent: () => version === this.updateVersion,
     });
-  }
-
-  private finishTileWait(globe?: {
-    tileLoadProgressEvent?: {
-      removeEventListener: (listener: (queueLength: number) => void) => void;
-    };
-  }): void {
-    if (this.tileProgressListener != null) {
-      globe?.tileLoadProgressEvent?.removeEventListener?.(
-        this.tileProgressListener,
-      );
-      this.tileProgressListener = null;
-    }
-    const resolve = this.tileProgressResolve;
-    this.tileProgressResolve = null;
-    resolve?.();
   }
 
   private attachImageryErrorHandler(
@@ -440,23 +383,23 @@ export class LexicFilterService extends BaseService {
     this.imageryErrorListener = () => {
       if (version !== this.updateVersion) return;
       this.showTileLoadError(version);
-      this.finishTileWait(
-        this.cesiumService?.viewerOrNull?.scene?.globe,
-      );
+      this.tileLoadWaiter.cancel();
     };
+    this.imageryErrorProvider = provider;
     provider.errorEvent.addEventListener(this.imageryErrorListener);
   }
 
   private detachImageryErrorHandler(): void {
     if (
       this.imageryErrorListener != null &&
-      this.currentImagery?.imageryProvider != null
+      this.imageryErrorProvider != null
     ) {
-      this.currentImagery.imageryProvider.errorEvent.removeEventListener(
+      this.imageryErrorProvider.errorEvent.removeEventListener(
         this.imageryErrorListener,
       );
     }
     this.imageryErrorListener = null;
+    this.imageryErrorProvider = null;
   }
 
   private showTileLoadError(version: number): void {
@@ -492,7 +435,7 @@ export class LexicFilterService extends BaseService {
 
   private removeFilteredLayer(): void {
     this.detachImageryErrorHandler();
-    this.finishTileWait(this.cesiumService?.viewerOrNull?.scene?.globe);
+    this.tileLoadWaiter.cancel();
 
     if (this.currentImagery == null) return;
 

--- a/ui/src/features/lexic/lexic-tile-load.test.ts
+++ b/ui/src/features/lexic/lexic-tile-load.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { LexicTileLoadWaiter } from './lexic-tile-load';
+
+function createViewerFixture() {
+  const progressListeners: Array<(queueLength: number) => void> = [];
+  const globe = {
+    tilesLoaded: true,
+    tileLoadProgressEvent: {
+      addEventListener: vi.fn((listener: (queueLength: number) => void) => {
+        progressListeners.push(listener);
+      }),
+      removeEventListener: vi.fn((listener: (queueLength: number) => void) => {
+        const index = progressListeners.indexOf(listener);
+        if (index >= 0) progressListeners.splice(index, 1);
+      }),
+    },
+  };
+
+  const viewer = {
+    scene: {
+      globe,
+      requestRender: vi.fn(),
+    },
+  };
+
+  return { viewer, globe, progressListeners };
+}
+
+describe('LexicTileLoadWaiter', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('resolves when tile queue drains after pending work', async () => {
+    const waiter = new LexicTileLoadWaiter();
+    const { viewer, globe, progressListeners } = createViewerFixture();
+    globe.tilesLoaded = false;
+
+    const waitPromise = waiter.wait(viewer as never, { isCurrent: () => true });
+
+    expect(progressListeners).toHaveLength(1);
+
+    progressListeners[0](2);
+    globe.tilesLoaded = true;
+    progressListeners[0](0);
+
+    await expect(waitPromise).resolves.toBeUndefined();
+    expect(globe.tileLoadProgressEvent.removeEventListener).toHaveBeenCalled();
+  });
+
+  it('resolves via idle settle when no tile work starts', async () => {
+    const waiter = new LexicTileLoadWaiter();
+    const { viewer, globe, progressListeners } = createViewerFixture();
+
+    const waitPromise = waiter.wait(viewer as never, { isCurrent: () => true });
+    expect(progressListeners).toHaveLength(1);
+
+    await vi.runAllTimersAsync();
+
+    await expect(waitPromise).resolves.toBeUndefined();
+    expect(globe.tileLoadProgressEvent.removeEventListener).toHaveBeenCalled();
+  });
+
+  it('keeps waiting while tiles are pending and never idle-times out mid-load', async () => {
+    const waiter = new LexicTileLoadWaiter();
+    const { viewer, globe, progressListeners } = createViewerFixture();
+    globe.tilesLoaded = false;
+
+    let hasSettled = false;
+    const waitPromise = waiter
+      .wait(viewer as never, { isCurrent: () => true })
+      .then(() => {
+        hasSettled = true;
+      });
+
+    progressListeners[0](3);
+    await vi.runAllTimersAsync();
+    expect(hasSettled).toBe(false);
+
+    globe.tilesLoaded = true;
+    progressListeners[0](0);
+    await waitPromise;
+    expect(hasSettled).toBe(true);
+  });
+
+  it('cancels the wait when cancel() is called', async () => {
+    const waiter = new LexicTileLoadWaiter();
+    const { viewer, globe, progressListeners } = createViewerFixture();
+    globe.tilesLoaded = false;
+
+    const waitPromise = waiter.wait(viewer as never, { isCurrent: () => true });
+    progressListeners[0](1);
+
+    waiter.cancel();
+
+    await expect(waitPromise).resolves.toBeUndefined();
+    expect(globe.tileLoadProgressEvent.removeEventListener).toHaveBeenCalled();
+  });
+
+  it('cancels the wait when isCurrent becomes false via progress callback', async () => {
+    const waiter = new LexicTileLoadWaiter();
+    const { viewer, globe, progressListeners } = createViewerFixture();
+    globe.tilesLoaded = false;
+
+    let isCurrent = true;
+    const waitPromise = waiter.wait(viewer as never, {
+      isCurrent: () => isCurrent,
+    });
+    isCurrent = false;
+    progressListeners[0](1);
+
+    await expect(waitPromise).resolves.toBeUndefined();
+  });
+
+  it('returns immediately when globe has no tileLoadProgressEvent', async () => {
+    const waiter = new LexicTileLoadWaiter();
+    const viewer = {
+      scene: {
+        globe: {},
+        requestRender: vi.fn(),
+      },
+    };
+
+    await expect(
+      waiter.wait(viewer as never, { isCurrent: () => true }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('returns immediately when isCurrent is already false', async () => {
+    const waiter = new LexicTileLoadWaiter();
+    const { viewer, progressListeners } = createViewerFixture();
+
+    await expect(
+      waiter.wait(viewer as never, { isCurrent: () => false }),
+    ).resolves.toBeUndefined();
+    expect(progressListeners).toHaveLength(0);
+  });
+});

--- a/ui/src/features/lexic/lexic-tile-load.ts
+++ b/ui/src/features/lexic/lexic-tile-load.ts
@@ -1,0 +1,80 @@
+import type { Viewer } from 'cesium';
+
+export interface LexicTileLoadWaitOptions {
+  /** Returns false when a newer update supersedes this wait. */
+  isCurrent: () => boolean;
+}
+
+/**
+ * Waits for Cesium to finish (or skip) the initial imagery tile load after a
+ * filtered layer is added to the viewer.
+ */
+export class LexicTileLoadWaiter {
+  private finishCurrent: (() => void) | null = null;
+
+  /**
+   * Completes when pending tiles drain, a short idle settle finds no work,
+   * or {@link cancel} is called.
+   */
+  async wait(
+    viewer: Viewer,
+    { isCurrent }: LexicTileLoadWaitOptions,
+  ): Promise<void> {
+    if (!isCurrent()) return;
+
+    const globe = viewer.scene.globe;
+    if (globe == null) return;
+
+    const progressEvent = globe.tileLoadProgressEvent;
+    if (typeof progressEvent?.addEventListener !== 'function') return;
+
+    this.cancel();
+
+    await new Promise<void>((resolve) => {
+      let hasSeenPendingTiles = false;
+      let idleTimer: ReturnType<typeof setTimeout> | null = null;
+
+      const finish = () => {
+        if (this.finishCurrent !== finish) return;
+        this.finishCurrent = null;
+        if (idleTimer != null) clearTimeout(idleTimer);
+        progressEvent.removeEventListener(onProgress);
+        resolve();
+      };
+
+      const onProgress = (queueLength: number) => {
+        if (!isCurrent()) {
+          finish();
+          return;
+        }
+        if (queueLength > 0) {
+          hasSeenPendingTiles = true;
+          if (idleTimer != null) {
+            clearTimeout(idleTimer);
+            idleTimer = null;
+          }
+        }
+        if (hasSeenPendingTiles && queueLength === 0 && globe.tilesLoaded) {
+          finish();
+        }
+      };
+
+      this.finishCurrent = finish;
+      progressEvent.addEventListener(onProgress);
+      viewer.scene.requestRender();
+
+      // If no tile work starts shortly (cached / empty), do not hang forever.
+      // Once pending tiles are observed, the idle timer is cleared and we wait
+      // until the queue drains — there is no hard cancel mid-load.
+      idleTimer = setTimeout(() => {
+        idleTimer = null;
+        if (!hasSeenPendingTiles) finish();
+      }, 100);
+    });
+  }
+
+  /** Cancels any in-flight wait and resolves its promise. */
+  cancel(): void {
+    this.finishCurrent?.();
+  }
+}

--- a/ui/vitest.config.ts
+++ b/ui/vitest.config.ts
@@ -5,6 +5,8 @@ export default defineConfig({
   test: {
     environment: 'node',
     globals: true,
+    include: ['src/**/*.test.ts'],
+    exclude: ['src/**/*.ogc.test.ts', 'node_modules'],
     setupFiles: ['./src/test/setup.ts'],
   },
   resolve: {


### PR DESCRIPTION
This PR implements:
a loading indicator to inform about map-tiles (of filters) being loaded by cesium.
reports errors via Snackbar for failed lexic API requests and closes lexic panel or filter dialog if becoming unusable.
Translates "OR" and "AND" separators.

**Attention**: Lexic integration is unit tested. Therefore a new `unit-test` script-task was added to the `ui/package.json` and a new `test-ui` job was added to the github pipeline 