### PR TITLE
quickfix: increased common REQUEST-TIMEOUT value to 8s 

### DIFF
--- a/ui/src/constants.ts
+++ b/ui/src/constants.ts
@@ -228,7 +228,7 @@ export interface WmtsCapabilitiesLinks {
 
 export const DEFAULT_WMTS_SERVICE = 'maps.geo.admin';
 
-export const TIMEOUT_REQUEST_AFTER_MILLISECONDS = 5_000;
+export const TIMEOUT_REQUEST_AFTER_MILLISECONDS = 8_000;
 export const WMTS_CAPABILITIES_BY_SERVICE: Record<
   string,
   WmtsCapabilitiesLinks


### PR DESCRIPTION
The Request-Timeout is a workaround for failing layers in the sidebar making the UI hang.
We increased the value tonot break lexic translations. This is a temporary fix and we should takle the problem with failing layers, which made this setting even necessary